### PR TITLE
Anchor repositioning

### DIFF
--- a/sources/LavishlyYours.glyphs
+++ b/sources/LavishlyYours.glyphs
@@ -1,5 +1,16 @@
 {
-.appVersion = "3112";
+.appVersion = "1359";
+DisplayStrings = (
+"nn/zero.lf nnoo/Placeholder oo\012iii/Placeholder iii",
+"¾/space 000/Placeholder 00\012OO/Placeholder OO"
+);
+classes = (
+{
+automatic = 1;
+code = "A Aacute Abreve Abreveacute Abrevedotbelow Abrevegrave Abrevehookabove Abrevetilde Acaron Acircumflex Acircumflexacute Acircumflexdotbelow Acircumflexgrave Acircumflexhookabove Acircumflextilde Adblgrave Adieresis Adotbelow Agrave Ahookabove Ainvertedbreve Amacron Aogonek Aring Aringacute Atilde AE AEacute B C Cacute Ccaron Ccedilla Ccircumflex Cdotaccent D DZcaron Eth Dcaron Dcroat Dzcaron E Eacute Ebreve Ecaron Ecircumflex Ecircumflexacute Ecircumflexdotbelow Ecircumflexgrave Ecircumflexhookabove Ecircumflextilde Edblgrave Edieresis Edotaccent Edotbelow Egrave Ehookabove Einvertedbreve Emacron Eogonek Etilde F G Gbreve Gcaron Gcircumflex Gcommaaccent Gdotaccent H Hbar Hcircumflex I Iacute Ibreve Icaron Icircumflex Idblgrave Idieresis Idotaccent Idotbelow Igrave Ihookabove Iinvertedbreve Imacron Iogonek Itilde J Jcircumflex K Kcommaaccent L LJ Lacute Lcaron Lcommaaccent Ldot Lj Lslash M N NJ Nacute Ncaron Ncommaaccent Eng Nj Ntilde O Oacute Obreve Ocaron Ocircumflex Ocircumflexacute Ocircumflexdotbelow Ocircumflexgrave Ocircumflexhookabove Ocircumflextilde Odblgrave Odieresis Odieresismacron Odotaccentmacron Odotbelow Ograve Ohookabove Ohorn Ohornacute Ohorndotbelow Ohorngrave Ohornhookabove Ohorntilde Ohungarumlaut Oinvertedbreve Omacron Oogonek Oslash Oslashacute Otilde Otildemacron OE P Thorn Q R Racute Rcaron Rcommaaccent Rdblgrave Rinvertedbreve S Sacute Scaron Scedilla Scircumflex Scommaaccent Germandbls Schwa T Tbar Tcaron Tcedilla Tcommaaccent U Uacute Ubreve Ucaron Ucircumflex Udblgrave Udieresis Udieresiscaron Udieresisgrave Udieresismacron Udotbelow Ugrave Uhookabove Uhorn Uhornacute Uhorndotbelow Uhorngrave Uhornhookabove Uhorntilde Uhungarumlaut Uinvertedbreve Umacron Uogonek Uring Utilde V W Wacute Wcircumflex Wdieresis Wgrave X Y Yacute Ycircumflex Ydieresis Ydotbelow Ygrave Yhookabove Ymacron Ytilde Z Zacute Zcaron Zdotaccent";
+name = Uppercase;
+}
+);
 copyright = "Copyright 2014-2021 The Lavishly Yours Project Authors (https://github.com/googlefonts/lavishly-yours)";
 customParameters = (
 {
@@ -32,19 +43,6 @@ value = "This Font Software is licensed under the SIL Open Font License, Version
 {
 name = vendorID;
 value = GOOG;
-},
-{
-name = Axes;
-value = (
-{
-Name = Weight;
-Tag = wght;
-},
-{
-Name = Width;
-Tag = wdth;
-}
-);
 }
 );
 date = "2022-02-07 15:36:42 +0000";
@@ -67,7 +65,7 @@ name = aalt;
 },
 {
 automatic = 1;
-code = "lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb breveinvertedcomb caroncomb circumflexcomb commaturnedabovecomb dblgravecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb strokeshortcomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	lookupflag 0;\012	sub ringcomb acutecomb by ringcomb_acutecomb;\012	sub tildecomb dotaccentcomb by tildecomb_dotaccentcomb;\012	sub tildecomb macroncomb by tildecomb_macroncomb;\012} ccmp_Other_2;\012\012lookup ccmp_latn_1 {\012	sub fi by f i;\012	sub fl by f l;\012	sub Ldot by L periodcentered.loclCAT.case;\012	sub lj by l j;\012	sub Lj by L j;\012	sub LJ by L J;\012	sub nj by n j;\012	sub Nj by N j;\012	sub NJ by N J;\012	sub dzcaron by d zcaron;\012	sub Dzcaron by D zcaron;\012	sub DZcaron by D Zcaron;\012} ccmp_latn_1;\012\012lookup ccmp_latn_2 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012} ccmp_latn_2;\012\012script latn;\012lookup ccmp_latn_1;\012lookup ccmp_latn_2;\012";
+code = "lookup ccmp_Other_1 {\012	@CombiningTopAccents = [acutecomb brevecomb breveinvertedcomb caroncomb circumflexcomb commaturnedabovecomb dblgravecomb dieresiscomb dotaccentcomb gravecomb hookabovecomb hungarumlautcomb macroncomb ringcomb tildecomb];\012	@CombiningNonTopAccents = [brevebelowcomb cedillacomb dieresisbelowcomb dotbelowcomb macronbelowcomb ogonekcomb horncomb strokeshortcomb];\012	sub [i j]' @CombiningTopAccents by [idotless jdotless];\012	sub [i j]' @CombiningNonTopAccents @CombiningTopAccents by [idotless jdotless];\012	@Markscomb = [dieresiscomb dotaccentcomb gravecomb acutecomb hungarumlautcomb caroncomb.alt circumflexcomb caroncomb brevecomb ringcomb ringcomb_acutecomb tildecomb tildecomb_dotaccentcomb tildecomb_macroncomb macroncomb hookabovecomb dblgravecomb breveinvertedcomb commaturnedabovecomb dotbelowcomb dieresisbelowcomb commaaccentcomb macronbelowcomb strokeshortcomb brevecomb_acutecomb brevecomb_gravecomb brevecomb_hookabovecomb brevecomb_tildecomb circumflexcomb_acutecomb circumflexcomb_gravecomb circumflexcomb_hookabovecomb circumflexcomb_tildecomb];\012	@MarkscombCase = [dieresiscomb.case dotaccentcomb.case gravecomb.case acutecomb.case hungarumlautcomb.case caroncomb.alt.case circumflexcomb.case caroncomb.case brevecomb.case ringcomb.case ringcomb_acutecomb.case tildecomb.case tildecomb_dotaccentcomb.case tildecomb_macroncomb.case macroncomb.case hookabovecomb.case dblgravecomb.case breveinvertedcomb.case commaturnedabovecomb.case dotbelowcomb.case dieresisbelowcomb.case commaaccentcomb.case macronbelowcomb.case strokeshortcomb.case brevecomb_acutecomb.case brevecomb_gravecomb.case brevecomb_hookabovecomb.case brevecomb_tildecomb.case circumflexcomb_acutecomb.case circumflexcomb_gravecomb.case circumflexcomb_hookabovecomb.case circumflexcomb_tildecomb.case];\012	sub @Markscomb @Markscomb' by @MarkscombCase;\012	sub @Uppercase @Markscomb' by @MarkscombCase;\012} ccmp_Other_1;\012\012lookup ccmp_Other_2 {\012	sub @Markscomb' @MarkscombCase by @MarkscombCase;\012	sub @MarkscombCase @Markscomb' by @MarkscombCase;\012} ccmp_Other_2;\012\012lookup ccmp_Other_3 {\012	lookupflag 0;\012	sub ringcomb acutecomb by ringcomb_acutecomb;\012	sub ringcomb.case acutecomb.case by ringcomb_acutecomb.case;\012	sub tildecomb dotaccentcomb by tildecomb_dotaccentcomb;\012	sub tildecomb.case dotaccentcomb.case by tildecomb_dotaccentcomb.case;\012	sub tildecomb macroncomb by tildecomb_macroncomb;\012	sub tildecomb.case macroncomb.case by tildecomb_macroncomb.case;\012} ccmp_Other_3;\012\012lookup ccmp_latn_1 {\012	lookupflag 0;\012	sub brevecomb acutecomb by brevecomb_acutecomb;\012	sub brevecomb.case acutecomb.case by brevecomb_acutecomb.case;\012	sub brevecomb gravecomb by brevecomb_gravecomb;\012	sub brevecomb.case gravecomb.case by brevecomb_gravecomb.case;\012	sub brevecomb hookabovecomb by brevecomb_hookabovecomb;\012	sub brevecomb.case hookabovecomb.case by brevecomb_hookabovecomb.case;\012	sub brevecomb tildecomb by brevecomb_tildecomb;\012	sub brevecomb.case tildecomb.case by brevecomb_tildecomb.case;\012	sub circumflexcomb acutecomb by circumflexcomb_acutecomb;\012	sub circumflexcomb.case acutecomb.case by circumflexcomb_acutecomb.case;\012	sub circumflexcomb gravecomb by circumflexcomb_gravecomb;\012	sub circumflexcomb.case gravecomb.case by circumflexcomb_gravecomb.case;\012	sub circumflexcomb hookabovecomb by circumflexcomb_hookabovecomb;\012	sub circumflexcomb.case hookabovecomb.case by circumflexcomb_hookabovecomb.case;\012	sub circumflexcomb tildecomb by circumflexcomb_tildecomb;\012	sub circumflexcomb.case tildecomb.case by circumflexcomb_tildecomb.case;\012} ccmp_latn_1;\012\012script latn;\012lookup ccmp_latn_1;\012";
 name = ccmp;
 },
 {
@@ -102,7 +100,7 @@ name = onum;
 },
 {
 automatic = 1;
-code = "sub periodcentered.loclCAT by periodcentered.loclCAT.case;\012sub zero by zero.lf;\012sub one by one.lf;\012sub two by two.lf;\012sub three by three.lf;\012sub four by four.lf;\012sub five by five.lf;\012sub six by six.lf;\012sub seven by seven.lf;\012sub eight by eight.lf;\012sub nine by nine.lf;\012";
+code = "sub periodcentered.loclCAT by periodcentered.loclCAT.case;\012sub dieresiscomb by dieresiscomb.case;\012sub dotaccentcomb by dotaccentcomb.case;\012sub gravecomb by gravecomb.case;\012sub acutecomb by acutecomb.case;\012sub hungarumlautcomb by hungarumlautcomb.case;\012sub caroncomb.alt by caroncomb.alt.case;\012sub circumflexcomb by circumflexcomb.case;\012sub caroncomb by caroncomb.case;\012sub brevecomb by brevecomb.case;\012sub ringcomb by ringcomb.case;\012sub ringcomb_acutecomb by ringcomb_acutecomb.case;\012sub tildecomb by tildecomb.case;\012sub tildecomb_dotaccentcomb by tildecomb_dotaccentcomb.case;\012sub tildecomb_macroncomb by tildecomb_macroncomb.case;\012sub macroncomb by macroncomb.case;\012sub hookabovecomb by hookabovecomb.case;\012sub dblgravecomb by dblgravecomb.case;\012sub breveinvertedcomb by breveinvertedcomb.case;\012sub commaturnedabovecomb by commaturnedabovecomb.case;\012sub dotbelowcomb by dotbelowcomb.case;\012sub dieresisbelowcomb by dieresisbelowcomb.case;\012sub commaaccentcomb by commaaccentcomb.case;\012sub macronbelowcomb by macronbelowcomb.case;\012sub strokeshortcomb by strokeshortcomb.case;\012sub brevecomb_acutecomb by brevecomb_acutecomb.case;\012sub brevecomb_gravecomb by brevecomb_gravecomb.case;\012sub brevecomb_hookabovecomb by brevecomb_hookabovecomb.case;\012sub brevecomb_tildecomb by brevecomb_tildecomb.case;\012sub circumflexcomb_acutecomb by circumflexcomb_acutecomb.case;\012sub circumflexcomb_gravecomb by circumflexcomb_gravecomb.case;\012sub circumflexcomb_hookabovecomb by circumflexcomb_hookabovecomb.case;\012sub circumflexcomb_tildecomb by circumflexcomb_tildecomb.case;\012sub zero by zero.lf;\012sub one by one.lf;\012sub two by two.lf;\012sub three by three.lf;\012sub four by four.lf;\012sub five by five.lf;\012sub six by six.lf;\012sub seven by seven.lf;\012sub eight by eight.lf;\012sub nine by nine.lf;\012";
 name = case;
 },
 {
@@ -181,6 +179,14 @@ position = "{100, 344}";
 {
 locked = 1;
 position = "{33, -100}";
+},
+{
+locked = 1;
+position = "{258, 204}";
+},
+{
+angle = 90;
+position = "{250, -43}";
 }
 );
 horizontalStems = (
@@ -259,7 +265,7 @@ nodes = (
 width = 676;
 }
 );
-note = ".notdef";
+note = .notdef;
 },
 {
 glyphname = CR;
@@ -1035,7 +1041,7 @@ unicode = 0041;
 },
 {
 glyphname = Aacute;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1053,8 +1059,8 @@ components = (
 name = A;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1067,7 +1073,7 @@ unicode = 00C1;
 },
 {
 glyphname = Abreve;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1085,8 +1091,8 @@ components = (
 name = A;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1099,7 +1105,7 @@ unicode = 0102;
 },
 {
 glyphname = Abreveacute;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1117,8 +1123,8 @@ components = (
 name = A;
 },
 {
-name = brevecomb_acutecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb_acutecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1131,7 +1137,7 @@ unicode = 1EAE;
 },
 {
 glyphname = Abrevedotbelow;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1152,12 +1158,12 @@ components = (
 name = A;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 657, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 407, 0}";
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1170,7 +1176,7 @@ unicode = 1EB6;
 },
 {
 glyphname = Abrevegrave;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1188,8 +1194,8 @@ components = (
 name = A;
 },
 {
-name = brevecomb_gravecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb_gravecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1202,7 +1208,7 @@ unicode = 1EB0;
 },
 {
 glyphname = Abrevehookabove;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1220,8 +1226,8 @@ components = (
 name = A;
 },
 {
-name = brevecomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb_hookabovecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1234,7 +1240,7 @@ unicode = 1EB2;
 },
 {
 glyphname = Abrevetilde;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1252,8 +1258,8 @@ components = (
 name = A;
 },
 {
-name = brevecomb_tildecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = brevecomb_tildecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1266,7 +1272,7 @@ unicode = 1EB4;
 },
 {
 glyphname = Acaron;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1284,8 +1290,8 @@ components = (
 name = A;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1298,7 +1304,7 @@ unicode = 01CD;
 },
 {
 glyphname = Acircumflex;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1316,8 +1322,8 @@ components = (
 name = A;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1330,7 +1336,7 @@ unicode = 00C2;
 },
 {
 glyphname = Acircumflexacute;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1348,8 +1354,8 @@ components = (
 name = A;
 },
 {
-name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb_acutecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1362,7 +1368,7 @@ unicode = 1EA4;
 },
 {
 glyphname = Acircumflexdotbelow;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1383,12 +1389,12 @@ components = (
 name = A;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 657, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 407, 0}";
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1401,7 +1407,7 @@ unicode = 1EAC;
 },
 {
 glyphname = Acircumflexgrave;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1419,8 +1425,8 @@ components = (
 name = A;
 },
 {
-name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb_gravecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1433,7 +1439,7 @@ unicode = 1EA6;
 },
 {
 glyphname = Acircumflexhookabove;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1451,8 +1457,8 @@ components = (
 name = A;
 },
 {
-name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb_hookabovecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1465,7 +1471,7 @@ unicode = 1EA8;
 },
 {
 glyphname = Acircumflextilde;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1483,8 +1489,8 @@ components = (
 name = A;
 },
 {
-name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = circumflexcomb_tildecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1497,7 +1503,7 @@ unicode = 1EAA;
 },
 {
 glyphname = Adblgrave;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1515,8 +1521,8 @@ components = (
 name = A;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1529,7 +1535,7 @@ unicode = 0200;
 },
 {
 glyphname = Adieresis;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1547,8 +1553,8 @@ components = (
 name = A;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1561,7 +1567,7 @@ unicode = 00C4;
 },
 {
 glyphname = Adotbelow;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1579,8 +1585,8 @@ components = (
 name = A;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 657, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 407, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1593,7 +1599,7 @@ unicode = 1EA0;
 },
 {
 glyphname = Agrave;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1611,8 +1617,8 @@ components = (
 name = A;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1625,7 +1631,7 @@ unicode = 00C0;
 },
 {
 glyphname = Ahookabove;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1643,8 +1649,8 @@ components = (
 name = A;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1657,7 +1663,7 @@ unicode = 1EA2;
 },
 {
 glyphname = Ainvertedbreve;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1675,8 +1681,8 @@ components = (
 name = A;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1689,7 +1695,7 @@ unicode = 0202;
 },
 {
 glyphname = Amacron;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1707,8 +1713,8 @@ components = (
 name = A;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1721,7 +1727,7 @@ unicode = 0100;
 },
 {
 glyphname = Aogonek;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1740,7 +1746,7 @@ name = A;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 906, 0}";
+transform = "{1, 0, 0, 1, 656, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1753,7 +1759,7 @@ unicode = 0104;
 },
 {
 glyphname = Aring;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1771,8 +1777,8 @@ components = (
 name = A;
 },
 {
-name = ringcomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = ringcomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1785,7 +1791,7 @@ unicode = 00C5;
 },
 {
 glyphname = Aringacute;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1804,8 +1810,8 @@ components = (
 name = A;
 },
 {
-name = ringcomb_acutecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = ringcomb_acutecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -1818,7 +1824,7 @@ unicode = 01FA;
 },
 {
 glyphname = Atilde;
-lastChange = "2022-02-14 12:39:14 +0000";
+lastChange = "2022-03-01 14:19:53 +0000";
 layers = (
 {
 background = {
@@ -1836,8 +1842,8 @@ components = (
 name = A;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -2426,7 +2432,7 @@ unicode = 00C6;
 },
 {
 glyphname = AEacute;
-lastChange = "2022-02-14 12:39:20 +0000";
+lastChange = "2022-03-01 14:22:56 +0000";
 layers = (
 {
 background = {
@@ -2444,8 +2450,8 @@ components = (
 name = AE;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 874, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 624, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -3422,7 +3428,7 @@ unicode = 0043;
 },
 {
 glyphname = Cacute;
-lastChange = "2022-02-14 12:39:28 +0000";
+lastChange = "2022-03-01 14:20:00 +0000";
 layers = (
 {
 background = {
@@ -3440,8 +3446,8 @@ components = (
 name = C;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 454, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 204, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -3454,7 +3460,7 @@ unicode = 0106;
 },
 {
 glyphname = Ccaron;
-lastChange = "2022-02-14 12:39:28 +0000";
+lastChange = "2022-03-01 14:20:00 +0000";
 layers = (
 {
 background = {
@@ -3472,8 +3478,8 @@ components = (
 name = C;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 454, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 204, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -3486,7 +3492,7 @@ unicode = 010C;
 },
 {
 glyphname = Ccedilla;
-lastChange = "2022-02-14 12:39:28 +0000";
+lastChange = "2022-03-01 14:20:00 +0000";
 layers = (
 {
 background = {
@@ -3505,7 +3511,7 @@ name = C;
 },
 {
 name = cedillacomb;
-transform = "{1, 0, 0, 1, 245, -10}";
+transform = "{1, 0, 0, 1, -5, -10}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -3518,7 +3524,7 @@ unicode = 00C7;
 },
 {
 glyphname = Ccircumflex;
-lastChange = "2022-02-14 12:39:28 +0000";
+lastChange = "2022-03-01 14:20:00 +0000";
 layers = (
 {
 background = {
@@ -3536,8 +3542,8 @@ components = (
 name = C;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 454, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 204, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -3550,7 +3556,7 @@ unicode = 0108;
 },
 {
 glyphname = Cdotaccent;
-lastChange = "2022-02-14 12:39:28 +0000";
+lastChange = "2022-03-01 14:20:00 +0000";
 layers = (
 {
 background = {
@@ -3568,8 +3574,8 @@ components = (
 name = C;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 454, 426}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 204, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -4614,7 +4620,7 @@ unicode = 00D0;
 },
 {
 glyphname = Dcaron;
-lastChange = "2022-02-14 12:40:04 +0000";
+lastChange = "2022-03-01 14:20:10 +0000";
 layers = (
 {
 background = {
@@ -4632,8 +4638,8 @@ components = (
 name = D;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 505, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 255, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -4671,7 +4677,7 @@ unicode = 0110;
 },
 {
 glyphname = Dzcaron;
-lastChange = "2022-02-14 12:40:12 +0000";
+lastChange = "2022-03-01 14:20:10 +0000";
 layers = (
 {
 background = {
@@ -4705,7 +4711,7 @@ unicode = 01C5;
 {
 color = 3;
 glyphname = E;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 20:38:27 +0000";
 layers = (
 {
 anchors = (
@@ -4719,7 +4725,7 @@ position = "{652, 0}";
 },
 {
 name = top;
-position = "{464, 670}";
+position = "{464, 650}";
 }
 );
 background = {
@@ -5241,7 +5247,7 @@ unicode = 0045;
 },
 {
 glyphname = Eacute;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5259,8 +5265,8 @@ components = (
 name = E;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5273,7 +5279,7 @@ unicode = 00C9;
 },
 {
 glyphname = Ebreve;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5291,8 +5297,8 @@ components = (
 name = E;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5305,7 +5311,7 @@ unicode = 0114;
 },
 {
 glyphname = Ecaron;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5323,8 +5329,8 @@ components = (
 name = E;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5337,7 +5343,7 @@ unicode = 011A;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5355,8 +5361,8 @@ components = (
 name = E;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5369,7 +5375,7 @@ unicode = 00CA;
 },
 {
 glyphname = Ecircumflexacute;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5387,8 +5393,8 @@ components = (
 name = E;
 },
 {
-name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb_acutecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5401,7 +5407,7 @@ unicode = 1EBE;
 },
 {
 glyphname = Ecircumflexdotbelow;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5422,12 +5428,12 @@ components = (
 name = E;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 344, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 94, 0}";
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5440,7 +5446,7 @@ unicode = 1EC6;
 },
 {
 glyphname = Ecircumflexgrave;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5458,8 +5464,8 @@ components = (
 name = E;
 },
 {
-name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb_gravecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5472,7 +5478,7 @@ unicode = 1EC0;
 },
 {
 glyphname = Ecircumflexhookabove;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5490,8 +5496,8 @@ components = (
 name = E;
 },
 {
-name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb_hookabovecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5504,7 +5510,7 @@ unicode = 1EC2;
 },
 {
 glyphname = Ecircumflextilde;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5522,8 +5528,8 @@ components = (
 name = E;
 },
 {
-name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = circumflexcomb_tildecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5536,7 +5542,7 @@ unicode = 1EC4;
 },
 {
 glyphname = Edblgrave;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5554,8 +5560,8 @@ components = (
 name = E;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5568,7 +5574,7 @@ unicode = 0204;
 },
 {
 glyphname = Edieresis;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5586,8 +5592,8 @@ components = (
 name = E;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5600,7 +5606,7 @@ unicode = 00CB;
 },
 {
 glyphname = Edotaccent;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5618,8 +5624,8 @@ components = (
 name = E;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5632,7 +5638,7 @@ unicode = 0116;
 },
 {
 glyphname = Edotbelow;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5650,8 +5656,8 @@ components = (
 name = E;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 344, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 94, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5664,7 +5670,7 @@ unicode = 1EB8;
 },
 {
 glyphname = Egrave;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5682,8 +5688,8 @@ components = (
 name = E;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5696,7 +5702,7 @@ unicode = 00C8;
 },
 {
 glyphname = Ehookabove;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5714,8 +5720,8 @@ components = (
 name = E;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5728,7 +5734,7 @@ unicode = 1EBA;
 },
 {
 glyphname = Einvertedbreve;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5746,8 +5752,8 @@ components = (
 name = E;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5760,7 +5766,7 @@ unicode = 0206;
 },
 {
 glyphname = Emacron;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5778,8 +5784,8 @@ components = (
 name = E;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5792,7 +5798,7 @@ unicode = 0112;
 },
 {
 glyphname = Eogonek;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5811,7 +5817,7 @@ name = E;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 652, 0}";
+transform = "{1, 0, 0, 1, 402, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5824,7 +5830,7 @@ unicode = 0118;
 },
 {
 glyphname = Etilde;
-lastChange = "2022-02-14 12:40:24 +0000";
+lastChange = "2022-03-01 14:20:16 +0000";
 layers = (
 {
 background = {
@@ -5842,8 +5848,8 @@ components = (
 name = E;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 464, 426}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 214, 406}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -5853,125 +5859,6 @@ width = 747;
 leftKerningGroup = E;
 rightKerningGroup = E;
 unicode = 1EBC;
-},
-{
-glyphname = Schwa;
-lastChange = "2022-02-14 12:40:36 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"154 563 OFFCURVE",
-"255 648 OFFCURVE",
-"403 648 CURVE SMOOTH",
-"521 648 OFFCURVE",
-"606 585 OFFCURVE",
-"568 389 CURVE SMOOTH",
-"529 183 OFFCURVE",
-"341 0 OFFCURVE",
-"177 0 CURVE SMOOTH",
-"48 0 OFFCURVE",
-"79 152 OFFCURVE",
-"155 224 CURVE SMOOTH",
-"301 365 OFFCURVE",
-"489 360 OFFCURVE",
-"558 360 CURVE SMOOTH",
-"573 360 OFFCURVE",
-"578 375 OFFCURVE",
-"550 375 CURVE SMOOTH",
-"502 375 OFFCURVE",
-"301 400 OFFCURVE",
-"136 261 CURVE SMOOTH",
-"13 158 OFFCURVE",
-"-12 -20 OFFCURVE",
-"160 -20 CURVE SMOOTH",
-"611 -20 OFFCURVE",
-"821 679 OFFCURVE",
-"427 679 CURVE SMOOTH",
-"276 679 OFFCURVE",
-"155 593 OFFCURVE",
-"76 512 CURVE SMOOTH",
-"65 501 OFFCURVE",
-"79 492 OFFCURVE",
-"90 501 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"446 -20 OFFCURVE",
-"634 261 OFFCURVE",
-"634 466 CURVE SMOOTH",
-"634 585 OFFCURVE",
-"572 679 OFFCURVE",
-"427 679 CURVE SMOOTH",
-"276 679 OFFCURVE",
-"155 593 OFFCURVE",
-"76 512 CURVE SMOOTH",
-"73 509 OFFCURVE",
-"72 506 OFFCURVE",
-"72 503 CURVE SMOOTH",
-"72 500 OFFCURVE",
-"76 497 OFFCURVE",
-"81 497 CURVE SMOOTH",
-"84 497 OFFCURVE",
-"87 498 OFFCURVE",
-"90 501 CURVE SMOOTH",
-"154 563 OFFCURVE",
-"255 648 OFFCURVE",
-"403 648 CURVE SMOOTH",
-"502 648 OFFCURVE",
-"577 604 OFFCURVE",
-"577 475 CURVE SMOOTH",
-"577 450 OFFCURVE",
-"574 422 OFFCURVE",
-"568 389 CURVE SMOOTH",
-"529 183 OFFCURVE",
-"341 0 OFFCURVE",
-"177 0 CURVE SMOOTH",
-"114 0 OFFCURVE",
-"89 36 OFFCURVE",
-"89 82 CURVE SMOOTH",
-"89 130 OFFCURVE",
-"116 187 OFFCURVE",
-"155 224 CURVE SMOOTH",
-"301 365 OFFCURVE",
-"489 360 OFFCURVE",
-"558 360 CURVE SMOOTH",
-"565 360 OFFCURVE",
-"570 363 OFFCURVE",
-"570 367 CURVE SMOOTH",
-"570 371 OFFCURVE",
-"564 375 OFFCURVE",
-"550 375 CURVE SMOOTH",
-"538 375 OFFCURVE",
-"513 377 OFFCURVE",
-"482 377 CURVE SMOOTH",
-"397 377 OFFCURVE",
-"257 363 OFFCURVE",
-"136 261 CURVE SMOOTH",
-"74 210 OFFCURVE",
-"37 140 OFFCURVE",
-"37 82 CURVE SMOOTH",
-"37 25 OFFCURVE",
-"74 -20 OFFCURVE",
-"160 -20 CURVE SMOOTH"
-);
-}
-);
-width = 654;
-}
-);
-leftKerningGroup = Schwa;
-rightKerningGroup = O;
-unicode = 018F;
 },
 {
 glyphname = F;
@@ -7026,7 +6913,7 @@ unicode = 0047;
 },
 {
 glyphname = Gbreve;
-lastChange = "2022-02-14 12:40:46 +0000";
+lastChange = "2022-03-01 14:20:20 +0000";
 layers = (
 {
 background = {
@@ -7044,8 +6931,8 @@ components = (
 name = G;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 534, 476}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 284, 476}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -7058,7 +6945,7 @@ unicode = 011E;
 },
 {
 glyphname = Gcaron;
-lastChange = "2022-02-14 12:40:46 +0000";
+lastChange = "2022-03-01 14:20:20 +0000";
 layers = (
 {
 background = {
@@ -7076,8 +6963,8 @@ components = (
 name = G;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 534, 476}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 284, 476}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -7090,7 +6977,7 @@ unicode = 01E6;
 },
 {
 glyphname = Gcircumflex;
-lastChange = "2022-02-14 12:40:46 +0000";
+lastChange = "2022-03-01 14:20:20 +0000";
 layers = (
 {
 background = {
@@ -7108,8 +6995,8 @@ components = (
 name = G;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 534, 476}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 284, 476}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -7122,7 +7009,7 @@ unicode = 011C;
 },
 {
 glyphname = Gcommaaccent;
-lastChange = "2022-02-14 12:40:46 +0000";
+lastChange = "2022-03-01 14:20:20 +0000";
 layers = (
 {
 background = {
@@ -7140,8 +7027,8 @@ components = (
 name = G;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 130, -261}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, -120, -261}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -7154,7 +7041,7 @@ unicode = 0122;
 },
 {
 glyphname = Gdotaccent;
-lastChange = "2022-02-14 12:40:46 +0000";
+lastChange = "2022-03-01 14:20:20 +0000";
 layers = (
 {
 background = {
@@ -7172,8 +7059,8 @@ components = (
 name = G;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 534, 476}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 284, 476}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8086,7 +7973,7 @@ unicode = 0126;
 },
 {
 glyphname = Hcircumflex;
-lastChange = "2022-02-14 12:40:54 +0000";
+lastChange = "2022-03-01 14:20:23 +0000";
 layers = (
 {
 background = {
@@ -8104,8 +7991,8 @@ components = (
 name = H;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 906, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 656, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8549,7 +8436,7 @@ unicode = 0049;
 },
 {
 glyphname = Iacute;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8567,8 +8454,8 @@ components = (
 name = I;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8581,7 +8468,7 @@ unicode = 00CD;
 },
 {
 glyphname = Ibreve;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8599,8 +8486,8 @@ components = (
 name = I;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8613,7 +8500,7 @@ unicode = 012C;
 },
 {
 glyphname = Icaron;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8631,8 +8518,8 @@ components = (
 name = I;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8645,7 +8532,7 @@ unicode = 01CF;
 },
 {
 glyphname = Icircumflex;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8663,8 +8550,8 @@ components = (
 name = I;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8677,7 +8564,7 @@ unicode = 00CE;
 },
 {
 glyphname = Idblgrave;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8695,8 +8582,8 @@ components = (
 name = I;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8709,7 +8596,7 @@ unicode = 0208;
 },
 {
 glyphname = Idieresis;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8727,8 +8614,8 @@ components = (
 name = I;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8741,7 +8628,7 @@ unicode = 00CF;
 },
 {
 glyphname = Idotaccent;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8759,8 +8646,8 @@ components = (
 name = I;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8773,7 +8660,7 @@ unicode = 0130;
 },
 {
 glyphname = Idotbelow;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8791,8 +8678,8 @@ components = (
 name = I;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 219, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, -31, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8805,7 +8692,7 @@ unicode = 1ECA;
 },
 {
 glyphname = Igrave;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8823,8 +8710,8 @@ components = (
 name = I;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8837,7 +8724,7 @@ unicode = 00CC;
 },
 {
 glyphname = Ihookabove;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8855,8 +8742,8 @@ components = (
 name = I;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8869,7 +8756,7 @@ unicode = 1EC8;
 },
 {
 glyphname = Iinvertedbreve;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8887,8 +8774,8 @@ components = (
 name = I;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8901,7 +8788,7 @@ unicode = 020A;
 },
 {
 glyphname = Imacron;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8919,8 +8806,8 @@ components = (
 name = I;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8933,7 +8820,7 @@ unicode = 012A;
 },
 {
 glyphname = Iogonek;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8952,7 +8839,7 @@ name = I;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 427, 10}";
+transform = "{1, 0, 0, 1, 177, 10}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -8965,7 +8852,7 @@ unicode = 012E;
 },
 {
 glyphname = Itilde;
-lastChange = "2022-02-14 12:41:06 +0000";
+lastChange = "2022-03-01 14:20:27 +0000";
 layers = (
 {
 background = {
@@ -8983,8 +8870,8 @@ components = (
 name = I;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 439, 527}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 189, 527}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -9516,7 +9403,7 @@ unicode = 004A;
 },
 {
 glyphname = Jcircumflex;
-lastChange = "2022-02-14 12:41:20 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -9534,8 +9421,8 @@ components = (
 name = J;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 652, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 402, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -10167,7 +10054,7 @@ unicode = 004B;
 },
 {
 glyphname = Kcommaaccent;
-lastChange = "2022-02-14 12:41:33 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -10185,8 +10072,8 @@ components = (
 name = K;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 524, 0}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, 274, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -10744,7 +10631,7 @@ unicode = 004C;
 },
 {
 glyphname = LJ;
-lastChange = "2022-02-14 12:42:57 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -10777,7 +10664,7 @@ unicode = 01C7;
 },
 {
 glyphname = Lacute;
-lastChange = "2022-02-14 12:42:52 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -10795,8 +10682,8 @@ components = (
 name = L;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 971, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 721, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -10809,7 +10696,7 @@ unicode = 0139;
 },
 {
 glyphname = Lcaron;
-lastChange = "2022-02-14 12:42:52 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -10827,8 +10714,8 @@ components = (
 name = L;
 },
 {
-name = caroncomb.alt;
-transform = "{1, 0, 0, 1, 1061, 85}";
+name = caroncomb.alt.case;
+transform = "{1, 0, 0, 1, 811, 85}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -10841,7 +10728,7 @@ unicode = 013D;
 },
 {
 glyphname = Lcommaaccent;
-lastChange = "2022-02-14 12:42:52 +0000";
+lastChange = "2022-03-01 14:20:33 +0000";
 layers = (
 {
 background = {
@@ -10859,8 +10746,8 @@ components = (
 name = L;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 441, 0}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, 191, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -11177,7 +11064,7 @@ unicode = 013F;
 },
 {
 glyphname = Lj;
-lastChange = "2022-02-14 12:43:04 +0000";
+lastChange = "2022-03-01 14:20:44 +0000";
 layers = (
 {
 background = {
@@ -13093,7 +12980,7 @@ unicode = 004E;
 },
 {
 glyphname = NJ;
-lastChange = "2022-02-14 12:46:16 +0000";
+lastChange = "2022-03-01 14:20:44 +0000";
 layers = (
 {
 background = {
@@ -13126,7 +13013,7 @@ unicode = 01CA;
 },
 {
 glyphname = Nacute;
-lastChange = "2022-02-14 12:46:12 +0000";
+lastChange = "2022-03-01 14:20:44 +0000";
 layers = (
 {
 background = {
@@ -13144,8 +13031,8 @@ components = (
 name = N;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 851, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 601, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -13158,7 +13045,7 @@ unicode = 0143;
 },
 {
 glyphname = Ncaron;
-lastChange = "2022-02-14 12:46:12 +0000";
+lastChange = "2022-03-01 14:20:44 +0000";
 layers = (
 {
 background = {
@@ -13176,8 +13063,8 @@ components = (
 name = N;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 851, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 601, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -13190,7 +13077,7 @@ unicode = 0147;
 },
 {
 glyphname = Ncommaaccent;
-lastChange = "2022-02-14 12:46:12 +0000";
+lastChange = "2022-03-01 14:20:44 +0000";
 layers = (
 {
 background = {
@@ -13208,8 +13095,8 @@ components = (
 name = N;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 590, 0}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, 340, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -13219,71 +13106,6 @@ width = 980;
 leftKerningGroup = N;
 rightKerningGroup = N;
 unicode = 0145;
-},
-{
-glyphname = Nj;
-lastChange = "2022-02-14 12:46:20 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 1004, 0}";
-}
-);
-};
-components = (
-{
-name = N;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 980, 0}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 1185;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = j;
-unicode = 01CB;
-},
-{
-glyphname = Ntilde;
-lastChange = "2022-02-14 12:46:12 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = N;
-},
-{
-name = tildecomb;
-}
-);
-};
-components = (
-{
-name = N;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 851, 426}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 980;
-}
-);
-leftKerningGroup = N;
-rightKerningGroup = N;
-unicode = 00D1;
 },
 {
 glyphname = Eng;
@@ -13867,6 +13689,71 @@ rightKerningGroup = N;
 unicode = 014A;
 },
 {
+glyphname = Nj;
+lastChange = "2022-03-01 14:20:44 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 1004, 0}";
+}
+);
+};
+components = (
+{
+name = N;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 980, 0}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 1185;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = j;
+unicode = 01CB;
+},
+{
+glyphname = Ntilde;
+lastChange = "2022-03-01 14:20:44 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = N;
+},
+{
+name = tildecomb;
+}
+);
+};
+components = (
+{
+name = N;
+},
+{
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 601, 426}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 980;
+}
+);
+leftKerningGroup = N;
+rightKerningGroup = N;
+unicode = 00D1;
+},
+{
 color = 3;
 glyphname = O;
 lastChange = "2022-02-14 15:23:49 +0000";
@@ -14323,7 +14210,7 @@ unicode = 004F;
 },
 {
 glyphname = Oacute;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14341,8 +14228,8 @@ components = (
 name = O;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14355,7 +14242,7 @@ unicode = 00D3;
 },
 {
 glyphname = Obreve;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14373,8 +14260,8 @@ components = (
 name = O;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14387,7 +14274,7 @@ unicode = 014E;
 },
 {
 glyphname = Ocaron;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14405,8 +14292,8 @@ components = (
 name = O;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14419,7 +14306,7 @@ unicode = 01D1;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14437,8 +14324,8 @@ components = (
 name = O;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14451,7 +14338,7 @@ unicode = 00D4;
 },
 {
 glyphname = Ocircumflexacute;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14469,8 +14356,8 @@ components = (
 name = O;
 },
 {
-name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb_acutecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14483,7 +14370,7 @@ unicode = 1ED0;
 },
 {
 glyphname = Ocircumflexdotbelow;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14504,12 +14391,12 @@ components = (
 name = O;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 337, -30}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 87, -30}";
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14522,7 +14409,7 @@ unicode = 1ED8;
 },
 {
 glyphname = Ocircumflexgrave;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14540,8 +14427,8 @@ components = (
 name = O;
 },
 {
-name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb_gravecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14554,7 +14441,7 @@ unicode = 1ED2;
 },
 {
 glyphname = Ocircumflexhookabove;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14572,8 +14459,8 @@ components = (
 name = O;
 },
 {
-name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb_hookabovecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14586,7 +14473,7 @@ unicode = 1ED4;
 },
 {
 glyphname = Ocircumflextilde;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14604,8 +14491,8 @@ components = (
 name = O;
 },
 {
-name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = circumflexcomb_tildecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14618,7 +14505,7 @@ unicode = 1ED6;
 },
 {
 glyphname = Odblgrave;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14636,8 +14523,8 @@ components = (
 name = O;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14650,7 +14537,7 @@ unicode = 020C;
 },
 {
 glyphname = Odieresis;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14668,8 +14555,8 @@ components = (
 name = O;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14681,8 +14568,9 @@ rightKerningGroup = O;
 unicode = 00D6;
 },
 {
+color = 9;
 glyphname = Odieresismacron;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 15:41:28 +0000";
 layers = (
 {
 background = {
@@ -14703,12 +14591,12 @@ components = (
 name = O;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 536, 696}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 286, 696}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14720,8 +14608,9 @@ rightKerningGroup = O;
 unicode = 022A;
 },
 {
+color = 9;
 glyphname = Odotaccentmacron;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 15:41:28 +0000";
 layers = (
 {
 background = {
@@ -14742,12 +14631,12 @@ components = (
 name = O;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 536, 696}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 286, 696}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14760,7 +14649,7 @@ unicode = 0230;
 },
 {
 glyphname = Odotbelow;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14778,8 +14667,8 @@ components = (
 name = O;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 337, -30}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 87, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14792,7 +14681,7 @@ unicode = 1ECC;
 },
 {
 glyphname = Ograve;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14810,8 +14699,8 @@ components = (
 name = O;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14824,7 +14713,7 @@ unicode = 00D2;
 },
 {
 glyphname = Ohookabove;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14842,8 +14731,8 @@ components = (
 name = O;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14856,7 +14745,7 @@ unicode = 1ECE;
 },
 {
 glyphname = Ohorn;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14876,7 +14765,7 @@ name = O;
 },
 {
 name = horncomb;
-transform = "{1, 0, 0, 1, 721, 426}";
+transform = "{1, 0, 0, 1, 471, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14889,7 +14778,7 @@ unicode = 01A0;
 },
 {
 glyphname = Ohornacute;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14907,8 +14796,8 @@ components = (
 name = Ohorn;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14921,7 +14810,7 @@ unicode = 1EDA;
 },
 {
 glyphname = Ohorndotbelow;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14939,8 +14828,8 @@ components = (
 name = Ohorn;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 337, -30}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 87, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14953,7 +14842,7 @@ unicode = 1EE2;
 },
 {
 glyphname = Ohorngrave;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -14971,8 +14860,8 @@ components = (
 name = Ohorn;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -14985,7 +14874,7 @@ unicode = 1EDC;
 },
 {
 glyphname = Ohornhookabove;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15003,8 +14892,8 @@ components = (
 name = Ohorn;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15017,7 +14906,7 @@ unicode = 1EDE;
 },
 {
 glyphname = Ohorntilde;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15035,8 +14924,8 @@ components = (
 name = Ohorn;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15049,7 +14938,7 @@ unicode = 1EE0;
 },
 {
 glyphname = Ohungarumlaut;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15067,8 +14956,8 @@ components = (
 name = O;
 },
 {
-name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = hungarumlautcomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15081,7 +14970,7 @@ unicode = 0150;
 },
 {
 glyphname = Oinvertedbreve;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15099,8 +14988,8 @@ components = (
 name = O;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15113,7 +15002,7 @@ unicode = 020E;
 },
 {
 glyphname = Omacron;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15131,8 +15020,8 @@ components = (
 name = O;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15145,7 +15034,7 @@ unicode = 014C;
 },
 {
 glyphname = Oogonek;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:52 +0000";
 layers = (
 {
 background = {
@@ -15164,7 +15053,7 @@ name = O;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 478, 0}";
+transform = "{1, 0, 0, 1, 228, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15499,7 +15388,7 @@ unicode = 00D8;
 },
 {
 glyphname = Oslashacute;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:57 +0000";
 layers = (
 {
 background = {
@@ -15517,8 +15406,8 @@ components = (
 name = Oslash;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 636, 556}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 386, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15531,7 +15420,7 @@ unicode = 01FE;
 },
 {
 glyphname = Otilde;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:57 +0000";
 layers = (
 {
 background = {
@@ -15549,8 +15438,8 @@ components = (
 name = O;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -15563,7 +15452,7 @@ unicode = 00D5;
 },
 {
 glyphname = Otildemacron;
-lastChange = "2022-02-14 12:46:37 +0000";
+lastChange = "2022-03-01 14:20:57 +0000";
 layers = (
 {
 background = {
@@ -15581,8 +15470,8 @@ components = (
 name = O;
 },
 {
-name = tildecomb_macroncomb;
-transform = "{1, 0, 0, 1, 536, 556}";
+name = tildecomb_macroncomb.case;
+transform = "{1, 0, 0, 1, 286, 556}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -17646,7 +17535,7 @@ unicode = 0051;
 {
 color = 3;
 glyphname = R;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 21:16:16 +0000";
 layers = (
 {
 anchors = (
@@ -17656,7 +17545,7 @@ position = "{428, 0}";
 },
 {
 name = top;
-position = "{488, 670}";
+position = "{488, 700}";
 }
 );
 background = {
@@ -18296,7 +18185,7 @@ unicode = 0052;
 },
 {
 glyphname = Racute;
-lastChange = "2022-02-14 12:54:19 +0000";
+lastChange = "2022-03-01 14:21:07 +0000";
 layers = (
 {
 background = {
@@ -18314,8 +18203,8 @@ components = (
 name = R;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 488, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 238, 456}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18328,7 +18217,7 @@ unicode = 0154;
 },
 {
 glyphname = Rcaron;
-lastChange = "2022-02-14 12:54:19 +0000";
+lastChange = "2022-03-01 14:21:07 +0000";
 layers = (
 {
 background = {
@@ -18346,8 +18235,8 @@ components = (
 name = R;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 488, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 238, 456}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18360,7 +18249,7 @@ unicode = 0158;
 },
 {
 glyphname = Rcommaaccent;
-lastChange = "2022-02-14 12:54:19 +0000";
+lastChange = "2022-03-01 14:21:07 +0000";
 layers = (
 {
 background = {
@@ -18378,8 +18267,8 @@ components = (
 name = R;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 428, 0}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, 178, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18392,7 +18281,7 @@ unicode = 0156;
 },
 {
 glyphname = Rdblgrave;
-lastChange = "2022-02-14 12:54:19 +0000";
+lastChange = "2022-03-01 14:21:07 +0000";
 layers = (
 {
 background = {
@@ -18410,8 +18299,8 @@ components = (
 name = R;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 488, 426}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 238, 456}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18424,7 +18313,7 @@ unicode = 0210;
 },
 {
 glyphname = Rinvertedbreve;
-lastChange = "2022-02-14 12:54:19 +0000";
+lastChange = "2022-03-01 14:21:07 +0000";
 layers = (
 {
 background = {
@@ -18442,8 +18331,8 @@ components = (
 name = R;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 488, 426}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 238, 456}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18457,7 +18346,7 @@ unicode = 0212;
 {
 color = 3;
 glyphname = S;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 21:16:20 +0000";
 layers = (
 {
 anchors = (
@@ -18895,7 +18784,7 @@ unicode = 0053;
 },
 {
 glyphname = Sacute;
-lastChange = "2022-02-14 12:54:26 +0000";
+lastChange = "2022-03-01 14:21:12 +0000";
 layers = (
 {
 background = {
@@ -18913,8 +18802,8 @@ components = (
 name = S;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 590, 452}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 340, 452}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18927,7 +18816,7 @@ unicode = 015A;
 },
 {
 glyphname = Scaron;
-lastChange = "2022-02-14 12:54:26 +0000";
+lastChange = "2022-03-01 14:21:12 +0000";
 layers = (
 {
 background = {
@@ -18945,8 +18834,8 @@ components = (
 name = S;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 590, 452}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 340, 452}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -18959,7 +18848,7 @@ unicode = 0160;
 },
 {
 glyphname = Scedilla;
-lastChange = "2022-02-14 12:54:26 +0000";
+lastChange = "2022-03-01 14:21:12 +0000";
 layers = (
 {
 background = {
@@ -18990,7 +18879,7 @@ unicode = 015E;
 },
 {
 glyphname = Scircumflex;
-lastChange = "2022-02-14 12:54:26 +0000";
+lastChange = "2022-03-01 14:21:12 +0000";
 layers = (
 {
 background = {
@@ -19008,8 +18897,8 @@ components = (
 name = S;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 590, 452}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 340, 452}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -19022,7 +18911,7 @@ unicode = 015C;
 },
 {
 glyphname = Scommaaccent;
-lastChange = "2022-02-14 12:54:26 +0000";
+lastChange = "2022-03-01 14:21:12 +0000";
 layers = (
 {
 background = {
@@ -19040,8 +18929,8 @@ components = (
 name = S;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 299, -140}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, 49, -140}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -19422,6 +19311,125 @@ width = 491;
 }
 );
 unicode = 1E9E;
+},
+{
+glyphname = Schwa;
+lastChange = "2022-02-14 12:40:36 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"154 563 OFFCURVE",
+"255 648 OFFCURVE",
+"403 648 CURVE SMOOTH",
+"521 648 OFFCURVE",
+"606 585 OFFCURVE",
+"568 389 CURVE SMOOTH",
+"529 183 OFFCURVE",
+"341 0 OFFCURVE",
+"177 0 CURVE SMOOTH",
+"48 0 OFFCURVE",
+"79 152 OFFCURVE",
+"155 224 CURVE SMOOTH",
+"301 365 OFFCURVE",
+"489 360 OFFCURVE",
+"558 360 CURVE SMOOTH",
+"573 360 OFFCURVE",
+"578 375 OFFCURVE",
+"550 375 CURVE SMOOTH",
+"502 375 OFFCURVE",
+"301 400 OFFCURVE",
+"136 261 CURVE SMOOTH",
+"13 158 OFFCURVE",
+"-12 -20 OFFCURVE",
+"160 -20 CURVE SMOOTH",
+"611 -20 OFFCURVE",
+"821 679 OFFCURVE",
+"427 679 CURVE SMOOTH",
+"276 679 OFFCURVE",
+"155 593 OFFCURVE",
+"76 512 CURVE SMOOTH",
+"65 501 OFFCURVE",
+"79 492 OFFCURVE",
+"90 501 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"446 -20 OFFCURVE",
+"634 261 OFFCURVE",
+"634 466 CURVE SMOOTH",
+"634 585 OFFCURVE",
+"572 679 OFFCURVE",
+"427 679 CURVE SMOOTH",
+"276 679 OFFCURVE",
+"155 593 OFFCURVE",
+"76 512 CURVE SMOOTH",
+"73 509 OFFCURVE",
+"72 506 OFFCURVE",
+"72 503 CURVE SMOOTH",
+"72 500 OFFCURVE",
+"76 497 OFFCURVE",
+"81 497 CURVE SMOOTH",
+"84 497 OFFCURVE",
+"87 498 OFFCURVE",
+"90 501 CURVE SMOOTH",
+"154 563 OFFCURVE",
+"255 648 OFFCURVE",
+"403 648 CURVE SMOOTH",
+"502 648 OFFCURVE",
+"577 604 OFFCURVE",
+"577 475 CURVE SMOOTH",
+"577 450 OFFCURVE",
+"574 422 OFFCURVE",
+"568 389 CURVE SMOOTH",
+"529 183 OFFCURVE",
+"341 0 OFFCURVE",
+"177 0 CURVE SMOOTH",
+"114 0 OFFCURVE",
+"89 36 OFFCURVE",
+"89 82 CURVE SMOOTH",
+"89 130 OFFCURVE",
+"116 187 OFFCURVE",
+"155 224 CURVE SMOOTH",
+"301 365 OFFCURVE",
+"489 360 OFFCURVE",
+"558 360 CURVE SMOOTH",
+"565 360 OFFCURVE",
+"570 363 OFFCURVE",
+"570 367 CURVE SMOOTH",
+"570 371 OFFCURVE",
+"564 375 OFFCURVE",
+"550 375 CURVE SMOOTH",
+"538 375 OFFCURVE",
+"513 377 OFFCURVE",
+"482 377 CURVE SMOOTH",
+"397 377 OFFCURVE",
+"257 363 OFFCURVE",
+"136 261 CURVE SMOOTH",
+"74 210 OFFCURVE",
+"37 140 OFFCURVE",
+"37 82 CURVE SMOOTH",
+"37 25 OFFCURVE",
+"74 -20 OFFCURVE",
+"160 -20 CURVE SMOOTH"
+);
+}
+);
+width = 654;
+}
+);
+leftKerningGroup = Schwa;
+rightKerningGroup = O;
+unicode = 018F;
 },
 {
 color = 3;
@@ -20158,7 +20166,7 @@ unicode = 0166;
 },
 {
 glyphname = Tcaron;
-lastChange = "2022-02-14 12:55:00 +0000";
+lastChange = "2022-03-01 14:21:19 +0000";
 layers = (
 {
 background = {
@@ -20176,8 +20184,8 @@ components = (
 name = T;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 665, 426}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 415, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20190,7 +20198,7 @@ unicode = 0164;
 },
 {
 glyphname = Tcedilla;
-lastChange = "2022-02-14 12:55:00 +0000";
+lastChange = "2022-03-01 14:21:19 +0000";
 layers = (
 {
 background = {
@@ -20209,7 +20217,7 @@ name = T;
 },
 {
 name = cedillacomb;
-transform = "{1, 0, 0, 1, 288, -45}";
+transform = "{1, 0, 0, 1, 38, -45}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20222,7 +20230,7 @@ unicode = 0162;
 },
 {
 glyphname = Tcommaaccent;
-lastChange = "2022-02-14 12:55:00 +0000";
+lastChange = "2022-03-01 14:21:19 +0000";
 layers = (
 {
 background = {
@@ -20240,8 +20248,8 @@ components = (
 name = T;
 },
 {
-name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 228, -42}";
+name = commaaccentcomb.case;
+transform = "{1, 0, 0, 1, -22, -42}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20255,7 +20263,7 @@ unicode = 021A;
 {
 color = 3;
 glyphname = U;
-lastChange = "2022-02-14 21:32:33 +0000";
+lastChange = "2022-02-28 21:22:20 +0000";
 layers = (
 {
 anchors = (
@@ -20273,7 +20281,7 @@ position = "{750, 0}";
 },
 {
 name = top;
-position = "{862, 740}";
+position = "{862, 710}";
 }
 );
 background = {
@@ -20685,7 +20693,7 @@ unicode = 0055;
 },
 {
 glyphname = Uacute;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20703,8 +20711,8 @@ components = (
 name = U;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20717,7 +20725,7 @@ unicode = 00DA;
 },
 {
 glyphname = Ubreve;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20735,8 +20743,8 @@ components = (
 name = U;
 },
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = brevecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20749,7 +20757,7 @@ unicode = 016C;
 },
 {
 glyphname = Ucaron;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20767,8 +20775,8 @@ components = (
 name = U;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20781,7 +20789,7 @@ unicode = 01D3;
 },
 {
 glyphname = Ucircumflex;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20799,8 +20807,8 @@ components = (
 name = U;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20813,7 +20821,7 @@ unicode = 00DB;
 },
 {
 glyphname = Udblgrave;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20831,8 +20839,8 @@ components = (
 name = U;
 },
 {
-name = dblgravecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = dblgravecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20845,7 +20853,7 @@ unicode = 0214;
 },
 {
 glyphname = Udieresis;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -20863,8 +20871,8 @@ components = (
 name = U;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20876,8 +20884,9 @@ rightKerningGroup = U;
 unicode = 00DC;
 },
 {
+color = 9;
 glyphname = Udieresiscaron;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 15:41:28 +0000";
 layers = (
 {
 background = {
@@ -20898,12 +20907,12 @@ components = (
 name = U;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 862, 636}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 612, 606}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20915,8 +20924,9 @@ rightKerningGroup = U;
 unicode = 01D9;
 },
 {
+color = 9;
 glyphname = Udieresisgrave;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 15:41:28 +0000";
 layers = (
 {
 background = {
@@ -20937,12 +20947,12 @@ components = (
 name = U;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 862, 636}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 612, 606}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20954,8 +20964,9 @@ rightKerningGroup = U;
 unicode = 01DB;
 },
 {
+color = 9;
 glyphname = Udieresismacron;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 15:41:28 +0000";
 layers = (
 {
 background = {
@@ -20976,12 +20987,12 @@ components = (
 name = U;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 862, 636}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 612, 606}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -20994,7 +21005,7 @@ unicode = 01D5;
 },
 {
 glyphname = Udotbelow;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21012,8 +21023,8 @@ components = (
 name = U;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 562, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 312, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21026,7 +21037,7 @@ unicode = 1EE4;
 },
 {
 glyphname = Ugrave;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21044,8 +21055,8 @@ components = (
 name = U;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21058,7 +21069,7 @@ unicode = 00D9;
 },
 {
 glyphname = Uhookabove;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21076,8 +21087,8 @@ components = (
 name = U;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21090,7 +21101,7 @@ unicode = 1EE6;
 },
 {
 glyphname = Uhorn;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21110,7 +21121,7 @@ name = U;
 },
 {
 name = horncomb;
-transform = "{1, 0, 0, 1, 817, 300}";
+transform = "{1, 0, 0, 1, 567, 300}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21123,7 +21134,7 @@ unicode = 01AF;
 },
 {
 glyphname = Uhornacute;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21141,8 +21152,8 @@ components = (
 name = Uhorn;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21155,7 +21166,7 @@ unicode = 1EE8;
 },
 {
 glyphname = Uhorndotbelow;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21173,8 +21184,8 @@ components = (
 name = Uhorn;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 562, 0}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 312, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21187,7 +21198,7 @@ unicode = 1EF0;
 },
 {
 glyphname = Uhorngrave;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21205,8 +21216,8 @@ components = (
 name = Uhorn;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21219,7 +21230,7 @@ unicode = 1EEA;
 },
 {
 glyphname = Uhornhookabove;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21237,8 +21248,8 @@ components = (
 name = Uhorn;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21251,7 +21262,7 @@ unicode = 1EEC;
 },
 {
 glyphname = Uhorntilde;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21269,8 +21280,8 @@ components = (
 name = Uhorn;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21283,7 +21294,7 @@ unicode = 1EEE;
 },
 {
 glyphname = Uhungarumlaut;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21301,8 +21312,8 @@ components = (
 name = U;
 },
 {
-name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = hungarumlautcomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21315,7 +21326,7 @@ unicode = 0170;
 },
 {
 glyphname = Uinvertedbreve;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21333,8 +21344,8 @@ components = (
 name = U;
 },
 {
-name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = breveinvertedcomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21347,7 +21358,7 @@ unicode = 0216;
 },
 {
 glyphname = Umacron;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21365,8 +21376,8 @@ components = (
 name = U;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21379,7 +21390,7 @@ unicode = 016A;
 },
 {
 glyphname = Uogonek;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21398,7 +21409,7 @@ name = U;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 750, 0}";
+transform = "{1, 0, 0, 1, 500, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21411,7 +21422,7 @@ unicode = 0172;
 },
 {
 glyphname = Uring;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21429,8 +21440,8 @@ components = (
 name = U;
 },
 {
-name = ringcomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = ringcomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -21443,7 +21454,7 @@ unicode = 016E;
 },
 {
 glyphname = Utilde;
-lastChange = "2022-02-14 12:55:13 +0000";
+lastChange = "2022-03-01 14:21:25 +0000";
 layers = (
 {
 background = {
@@ -21461,8 +21472,8 @@ components = (
 name = U;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 862, 496}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 612, 466}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -22404,7 +22415,7 @@ unicode = 0057;
 },
 {
 glyphname = Wacute;
-lastChange = "2022-02-14 12:55:23 +0000";
+lastChange = "2022-03-01 14:21:58 +0000";
 layers = (
 {
 background = {
@@ -22422,8 +22433,8 @@ components = (
 name = W;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 1009, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 759, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -22436,7 +22447,7 @@ unicode = 1E82;
 },
 {
 glyphname = Wcircumflex;
-lastChange = "2022-02-14 12:55:23 +0000";
+lastChange = "2022-03-01 14:21:58 +0000";
 layers = (
 {
 background = {
@@ -22454,8 +22465,8 @@ components = (
 name = W;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 1009, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 759, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -22468,7 +22479,7 @@ unicode = 0174;
 },
 {
 glyphname = Wdieresis;
-lastChange = "2022-02-14 12:55:23 +0000";
+lastChange = "2022-03-01 14:21:58 +0000";
 layers = (
 {
 background = {
@@ -22486,8 +22497,8 @@ components = (
 name = W;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 1009, 426}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 759, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -22500,7 +22511,7 @@ unicode = 1E84;
 },
 {
 glyphname = Wgrave;
-lastChange = "2022-02-14 12:55:23 +0000";
+lastChange = "2022-03-01 14:21:58 +0000";
 layers = (
 {
 background = {
@@ -22518,8 +22529,8 @@ components = (
 name = W;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 1009, 426}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 759, 426}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -22963,7 +22974,7 @@ unicode = 0058;
 {
 color = 3;
 glyphname = Y;
-lastChange = "2022-02-14 21:32:33 +0000";
+lastChange = "2022-02-28 21:23:34 +0000";
 layers = (
 {
 anchors = (
@@ -22973,7 +22984,7 @@ position = "{319, -141}";
 },
 {
 name = top;
-position = "{776, 670}";
+position = "{756, 610}";
 }
 );
 background = {
@@ -23383,7 +23394,7 @@ unicode = 0059;
 },
 {
 glyphname = Yacute;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23401,8 +23412,8 @@ components = (
 name = Y;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23415,7 +23426,7 @@ unicode = 00DD;
 },
 {
 glyphname = Ycircumflex;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23433,8 +23444,8 @@ components = (
 name = Y;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23447,7 +23458,7 @@ unicode = 0176;
 },
 {
 glyphname = Ydieresis;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23465,8 +23476,8 @@ components = (
 name = Y;
 },
 {
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = dieresiscomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23479,7 +23490,7 @@ unicode = 0178;
 },
 {
 glyphname = Ydotbelow;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23497,8 +23508,8 @@ components = (
 name = Y;
 },
 {
-name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 319, -141}";
+name = dotbelowcomb.case;
+transform = "{1, 0, 0, 1, 69, -141}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23511,7 +23522,7 @@ unicode = 1EF4;
 },
 {
 glyphname = Ygrave;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23529,8 +23540,8 @@ components = (
 name = Y;
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23543,7 +23554,7 @@ unicode = 1EF2;
 },
 {
 glyphname = Yhookabove;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23561,8 +23572,8 @@ components = (
 name = Y;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23575,7 +23586,7 @@ unicode = 1EF6;
 },
 {
 glyphname = Ymacron;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23593,8 +23604,8 @@ components = (
 name = Y;
 },
 {
-name = macroncomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23607,7 +23618,7 @@ unicode = 0232;
 },
 {
 glyphname = Ytilde;
-lastChange = "2022-02-14 12:55:30 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -23625,8 +23636,8 @@ components = (
 name = Y;
 },
 {
-name = tildecomb;
-transform = "{1, 0, 0, 1, 776, 426}";
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 506, 366}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -23640,7 +23651,7 @@ unicode = 1EF8;
 {
 color = 3;
 glyphname = Z;
-lastChange = "2022-02-14 21:32:33 +0000";
+lastChange = "2022-02-28 21:26:33 +0000";
 layers = (
 {
 anchors = (
@@ -23650,7 +23661,7 @@ position = "{405, 0}";
 },
 {
 name = top;
-position = "{675, 740}";
+position = "{785, 730}";
 }
 );
 background = {
@@ -24178,7 +24189,7 @@ unicode = 005A;
 },
 {
 glyphname = Zacute;
-lastChange = "2022-02-14 12:55:36 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -24196,8 +24207,8 @@ components = (
 name = Z;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 675, 496}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 535, 486}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24210,7 +24221,7 @@ unicode = 0179;
 },
 {
 glyphname = Zcaron;
-lastChange = "2022-02-14 12:55:36 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -24228,8 +24239,8 @@ components = (
 name = Z;
 },
 {
-name = caroncomb;
-transform = "{1, 0, 0, 1, 675, 496}";
+name = caroncomb.case;
+transform = "{1, 0, 0, 1, 535, 486}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24242,7 +24253,7 @@ unicode = 017D;
 },
 {
 glyphname = Zdotaccent;
-lastChange = "2022-02-14 12:55:36 +0000";
+lastChange = "2022-03-01 14:22:04 +0000";
 layers = (
 {
 background = {
@@ -24260,8 +24271,8 @@ components = (
 name = Z;
 },
 {
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 675, 496}";
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 535, 486}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24275,13 +24286,13 @@ unicode = 017B;
 {
 color = 3;
 glyphname = a;
-lastChange = "2022-02-14 17:18:42 +0000";
+lastChange = "2022-02-28 16:10:55 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{82, 0}";
+position = "{79, 34}";
 },
 {
 name = ogonek;
@@ -24289,7 +24300,7 @@ position = "{227, 0}";
 },
 {
 name = top;
-position = "{208, 244}";
+position = "{208, 204}";
 }
 );
 background = {
@@ -24460,7 +24471,7 @@ unicode = 0061;
 },
 {
 glyphname = aacute;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24479,7 +24490,7 @@ name = a;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24491,7 +24502,7 @@ unicode = 00E1;
 },
 {
 glyphname = abreve;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24510,7 +24521,7 @@ name = a;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24522,7 +24533,7 @@ unicode = 0103;
 },
 {
 glyphname = abreveacute;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24541,7 +24552,7 @@ name = a;
 },
 {
 name = brevecomb_acutecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24553,7 +24564,7 @@ unicode = 1EAF;
 },
 {
 glyphname = abrevedotbelow;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24575,11 +24586,11 @@ name = a;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 82, 0}";
+transform = "{1, 0, 0, 1, -171, 34}";
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24591,7 +24602,7 @@ unicode = 1EB7;
 },
 {
 glyphname = abrevegrave;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24610,7 +24621,7 @@ name = a;
 },
 {
 name = brevecomb_gravecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24622,7 +24633,7 @@ unicode = 1EB1;
 },
 {
 glyphname = abrevehookabove;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24641,7 +24652,7 @@ name = a;
 },
 {
 name = brevecomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24653,7 +24664,7 @@ unicode = 1EB3;
 },
 {
 glyphname = abrevetilde;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24672,7 +24683,7 @@ name = a;
 },
 {
 name = brevecomb_tildecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24684,7 +24695,7 @@ unicode = 1EB5;
 },
 {
 glyphname = acaron;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24703,7 +24714,7 @@ name = a;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24715,7 +24726,7 @@ unicode = 01CE;
 },
 {
 glyphname = acircumflex;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24734,7 +24745,7 @@ name = a;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24746,7 +24757,7 @@ unicode = 00E2;
 },
 {
 glyphname = acircumflexacute;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24765,7 +24776,7 @@ name = a;
 },
 {
 name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24777,7 +24788,7 @@ unicode = 1EA5;
 },
 {
 glyphname = acircumflexdotbelow;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24799,11 +24810,11 @@ name = a;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 82, 0}";
+transform = "{1, 0, 0, 1, -171, 34}";
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24815,7 +24826,7 @@ unicode = 1EAD;
 },
 {
 glyphname = acircumflexgrave;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24834,7 +24845,7 @@ name = a;
 },
 {
 name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24846,7 +24857,7 @@ unicode = 1EA7;
 },
 {
 glyphname = acircumflexhookabove;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24865,7 +24876,7 @@ name = a;
 },
 {
 name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24877,7 +24888,7 @@ unicode = 1EA9;
 },
 {
 glyphname = acircumflextilde;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24896,7 +24907,7 @@ name = a;
 },
 {
 name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24908,7 +24919,7 @@ unicode = 1EAB;
 },
 {
 glyphname = adblgrave;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24927,7 +24938,7 @@ name = a;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24939,7 +24950,7 @@ unicode = 0201;
 },
 {
 glyphname = adieresis;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24958,7 +24969,7 @@ name = a;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -24970,7 +24981,7 @@ unicode = 00E4;
 },
 {
 glyphname = adotbelow;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -24989,7 +25000,7 @@ name = a;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 82, 0}";
+transform = "{1, 0, 0, 1, -171, 34}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25001,7 +25012,7 @@ unicode = 1EA1;
 },
 {
 glyphname = agrave;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25020,7 +25031,7 @@ name = a;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25032,7 +25043,7 @@ unicode = 00E0;
 },
 {
 glyphname = ahookabove;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25051,7 +25062,7 @@ name = a;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25063,7 +25074,7 @@ unicode = 1EA3;
 },
 {
 glyphname = ainvertedbreve;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25082,7 +25093,7 @@ name = a;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25094,7 +25105,7 @@ unicode = 0203;
 },
 {
 glyphname = amacron;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25113,7 +25124,7 @@ name = a;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25125,7 +25136,7 @@ unicode = 0101;
 },
 {
 glyphname = aogonek;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25144,7 +25155,7 @@ name = a;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 227, 0}";
+transform = "{1, 0, 0, 1, -23, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25156,7 +25167,7 @@ unicode = 0105;
 },
 {
 glyphname = aring;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:38 +0000";
 layers = (
 {
 background = {
@@ -25175,7 +25186,7 @@ name = a;
 },
 {
 name = ringcomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25186,8 +25197,9 @@ leftKerningGroup = a;
 unicode = 00E5;
 },
 {
+color = 3;
 glyphname = aringacute;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:46 +0000";
 layers = (
 {
 background = {
@@ -25208,13 +25220,8 @@ components = (
 name = a;
 },
 {
-name = ringcomb;
-transform = "{1, 0, 0, 1, 208, 0}";
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 308, 110}";
+name = ringcomb_acutecomb;
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25226,7 +25233,7 @@ unicode = 01FB;
 },
 {
 glyphname = atilde;
-lastChange = "2022-02-14 13:02:07 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25245,7 +25252,7 @@ name = a;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 208, 0}";
+transform = "{1, 0, 0, 1, -42, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25502,7 +25509,7 @@ unicode = 00E6;
 },
 {
 glyphname = aeacute;
-lastChange = "2022-02-14 13:02:13 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25521,7 +25528,7 @@ name = ae;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 248, 0}";
+transform = "{1, 0, 0, 1, -2, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25709,7 +25716,7 @@ unicode = 0062;
 {
 color = 3;
 glyphname = c;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-02-28 15:52:47 +0000";
 layers = (
 {
 anchors = (
@@ -25723,7 +25730,7 @@ position = "{112, 0}";
 },
 {
 name = top;
-position = "{194, 244}";
+position = "{189, 204}";
 }
 );
 background = {
@@ -25861,7 +25868,7 @@ unicode = 0063;
 },
 {
 glyphname = cacute;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25880,7 +25887,7 @@ name = c;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, -61, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25893,7 +25900,7 @@ unicode = 0107;
 },
 {
 glyphname = ccaron;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25912,7 +25919,7 @@ name = c;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, -61, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25925,7 +25932,7 @@ unicode = 010D;
 },
 {
 glyphname = ccedilla;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25944,7 +25951,7 @@ name = c;
 },
 {
 name = cedillacomb;
-transform = "{1, 0, 0, 1, 112, 0}";
+transform = "{1, 0, 0, 1, -138, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25957,7 +25964,7 @@ unicode = 00E7;
 },
 {
 glyphname = ccircumflex;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -25976,7 +25983,7 @@ name = c;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, -61, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -25989,7 +25996,7 @@ unicode = 0109;
 },
 {
 glyphname = cdotaccent;
-lastChange = "2022-02-14 13:03:10 +0000";
+lastChange = "2022-03-01 14:22:51 +0000";
 layers = (
 {
 background = {
@@ -26008,7 +26015,7 @@ name = c;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 194, 0}";
+transform = "{1, 0, 0, 1, -61, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26463,7 +26470,7 @@ unicode = 00F0;
 },
 {
 glyphname = dcaron;
-lastChange = "2022-02-14 13:04:13 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26482,7 +26489,7 @@ name = d;
 },
 {
 name = caroncomb.alt;
-transform = "{1, 0, 0, 1, 429, 0}";
+transform = "{1, 0, 0, 1, 179, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26495,7 +26502,7 @@ unicode = 010F;
 },
 {
 glyphname = dcroat;
-lastChange = "2022-02-14 13:04:13 +0000";
+lastChange = "2022-03-01 13:09:15 +0000";
 layers = (
 {
 background = {
@@ -26514,7 +26521,7 @@ name = d;
 },
 {
 name = strokeshortcomb;
-transform = "{1, 0, 0, 1, 338, 525}";
+transform = "{1, 0, 0, 1, 88, 225}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26527,7 +26534,7 @@ unicode = 0111;
 },
 {
 glyphname = dzcaron;
-lastChange = "2022-02-14 13:04:19 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26561,13 +26568,13 @@ unicode = 01C6;
 {
 color = 3;
 glyphname = e;
-lastChange = "2022-02-14 17:15:21 +0000";
+lastChange = "2022-02-28 16:11:05 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{51, 0}";
+position = "{71, 40}";
 },
 {
 name = ogonek;
@@ -26575,7 +26582,7 @@ position = "{156, 0}";
 },
 {
 name = top;
-position = "{177, 244}";
+position = "{167, 214}";
 }
 );
 background = {
@@ -26749,7 +26756,7 @@ unicode = 0065;
 },
 {
 glyphname = eacute;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26768,7 +26775,7 @@ name = e;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26781,7 +26788,7 @@ unicode = 00E9;
 },
 {
 glyphname = ebreve;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26800,7 +26807,7 @@ name = e;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26813,7 +26820,7 @@ unicode = 0115;
 },
 {
 glyphname = ecaron;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26832,7 +26839,7 @@ name = e;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26845,7 +26852,7 @@ unicode = 011B;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26864,7 +26871,7 @@ name = e;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26877,7 +26884,7 @@ unicode = 00EA;
 },
 {
 glyphname = ecircumflexacute;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26896,7 +26903,7 @@ name = e;
 },
 {
 name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26909,7 +26916,7 @@ unicode = 1EBF;
 },
 {
 glyphname = ecircumflexdotbelow;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26931,11 +26938,11 @@ name = e;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 51, 0}";
+transform = "{1, 0, 0, 1, -179, 40}";
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26948,7 +26955,7 @@ unicode = 1EC7;
 },
 {
 glyphname = ecircumflexgrave;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26967,7 +26974,7 @@ name = e;
 },
 {
 name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -26980,7 +26987,7 @@ unicode = 1EC1;
 },
 {
 glyphname = ecircumflexhookabove;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -26999,7 +27006,7 @@ name = e;
 },
 {
 name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27012,7 +27019,7 @@ unicode = 1EC3;
 },
 {
 glyphname = ecircumflextilde;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27031,7 +27038,7 @@ name = e;
 },
 {
 name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27044,7 +27051,7 @@ unicode = 1EC5;
 },
 {
 glyphname = edblgrave;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27063,7 +27070,7 @@ name = e;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27076,7 +27083,7 @@ unicode = 0205;
 },
 {
 glyphname = edieresis;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27095,7 +27102,7 @@ name = e;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27108,7 +27115,7 @@ unicode = 00EB;
 },
 {
 glyphname = edotaccent;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27127,7 +27134,7 @@ name = e;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27140,7 +27147,7 @@ unicode = 0117;
 },
 {
 glyphname = edotbelow;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27159,7 +27166,7 @@ name = e;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 51, 0}";
+transform = "{1, 0, 0, 1, -179, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27172,7 +27179,7 @@ unicode = 1EB9;
 },
 {
 glyphname = egrave;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27191,7 +27198,7 @@ name = e;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27204,7 +27211,7 @@ unicode = 00E8;
 },
 {
 glyphname = ehookabove;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27223,7 +27230,7 @@ name = e;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27236,7 +27243,7 @@ unicode = 1EBB;
 },
 {
 glyphname = einvertedbreve;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27255,7 +27262,7 @@ name = e;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27268,7 +27275,7 @@ unicode = 0207;
 },
 {
 glyphname = emacron;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27287,7 +27294,7 @@ name = e;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27300,7 +27307,7 @@ unicode = 0113;
 },
 {
 glyphname = eogonek;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27319,7 +27326,7 @@ name = e;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 156, 0}";
+transform = "{1, 0, 0, 1, -94, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27332,7 +27339,7 @@ unicode = 0119;
 },
 {
 glyphname = etilde;
-lastChange = "2022-02-14 13:04:28 +0000";
+lastChange = "2022-03-01 14:23:09 +0000";
 layers = (
 {
 background = {
@@ -27351,7 +27358,7 @@ name = e;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 177, 0}";
+transform = "{1, 0, 0, 1, -83, -30}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -27713,7 +27720,7 @@ unicode = 0066;
 {
 color = 3;
 glyphname = g;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 15:54:49 +0000";
 layers = (
 {
 anchors = (
@@ -27723,7 +27730,7 @@ position = "{-184, -438}";
 },
 {
 name = top;
-position = "{242, 244}";
+position = "{242, 209}";
 }
 );
 background = {
@@ -27914,7 +27921,7 @@ nodes = (
 "45 16 OFFCURVE",
 "71 16 CURVE SMOOTH",
 "96 16 OFFCURVE",
-"123 30 OFFCURVE",
+"124 29 OFFCURVE",
 "152 60 CURVE SMOOTH",
 "217 133 LINE",
 "212 77 OFFCURVE",
@@ -27979,7 +27986,7 @@ unicode = 0067;
 },
 {
 glyphname = gbreve;
-lastChange = "2022-02-14 13:04:43 +0000";
+lastChange = "2022-03-01 14:23:14 +0000";
 layers = (
 {
 background = {
@@ -27998,7 +28005,7 @@ name = g;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 242, 0}";
+transform = "{1, 0, 0, 1, -8, -35}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28011,7 +28018,7 @@ unicode = 011F;
 },
 {
 glyphname = gcaron;
-lastChange = "2022-02-14 13:04:43 +0000";
+lastChange = "2022-03-01 14:23:14 +0000";
 layers = (
 {
 background = {
@@ -28030,7 +28037,7 @@ name = g;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 242, 0}";
+transform = "{1, 0, 0, 1, -8, -35}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28043,7 +28050,7 @@ unicode = 01E7;
 },
 {
 glyphname = gcircumflex;
-lastChange = "2022-02-14 13:04:43 +0000";
+lastChange = "2022-03-01 14:23:14 +0000";
 layers = (
 {
 background = {
@@ -28062,7 +28069,7 @@ name = g;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 242, 0}";
+transform = "{1, 0, 0, 1, -8, -35}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28075,7 +28082,7 @@ unicode = 011D;
 },
 {
 glyphname = gcommaaccent;
-lastChange = "2022-02-14 13:04:43 +0000";
+lastChange = "2022-03-01 14:23:14 +0000";
 layers = (
 {
 background = {
@@ -28094,7 +28101,7 @@ name = g;
 },
 {
 name = commaturnedabovecomb;
-transform = "{1, 0, 0, 1, 242, 0}";
+transform = "{1, 0, 0, 1, -8, -35}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28107,7 +28114,7 @@ unicode = 0123;
 },
 {
 glyphname = gdotaccent;
-lastChange = "2022-02-14 13:04:43 +0000";
+lastChange = "2022-03-01 14:23:14 +0000";
 layers = (
 {
 background = {
@@ -28126,7 +28133,7 @@ name = g;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 242, 0}";
+transform = "{1, 0, 0, 1, -8, -35}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28140,7 +28147,7 @@ unicode = 0121;
 {
 color = 3;
 glyphname = h;
-lastChange = "2022-02-14 17:14:54 +0000";
+lastChange = "2022-02-28 16:11:21 +0000";
 layers = (
 {
 anchors = (
@@ -28154,7 +28161,7 @@ position = "{153, 350}";
 },
 {
 name = top;
-position = "{322, 511}";
+position = "{302, 461}";
 }
 );
 background = {
@@ -28378,7 +28385,7 @@ unicode = 0068;
 },
 {
 glyphname = hbar;
-lastChange = "2022-02-14 13:04:49 +0000";
+lastChange = "2022-03-01 13:09:15 +0000";
 layers = (
 {
 background = {
@@ -28397,7 +28404,7 @@ name = h;
 },
 {
 name = strokeshortcomb;
-transform = "{1, 0, 0, 1, 153, 475}";
+transform = "{1, 0, 0, 1, -97, 175}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28410,7 +28417,7 @@ unicode = 0127;
 },
 {
 glyphname = hcircumflex;
-lastChange = "2022-02-14 13:04:49 +0000";
+lastChange = "2022-03-01 14:23:17 +0000";
 layers = (
 {
 background = {
@@ -28428,8 +28435,8 @@ components = (
 name = h;
 },
 {
-name = circumflexcomb;
-transform = "{1, 0, 0, 1, 322, 267}";
+name = circumflexcomb.case;
+transform = "{1, 0, 0, 1, 52, 217}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28443,7 +28450,7 @@ unicode = 0125;
 {
 color = 3;
 glyphname = i;
-lastChange = "2022-02-14 19:18:36 +0000";
+lastChange = "2022-03-01 15:41:22 +0000";
 layers = (
 {
 anchors = (
@@ -28477,8 +28484,6 @@ paths = (
 {
 closed = 1;
 nodes = (
-"69 -8 OFFCURVE",
-"115 -8 CURVE SMOOTH",
 "142 -8 OFFCURVE",
 "171 3 OFFCURVE",
 "197 20 CURVE SMOOTH",
@@ -28515,7 +28520,9 @@ nodes = (
 "46 158 OFFCURVE",
 "36 120 OFFCURVE",
 "36 84 CURVE SMOOTH",
-"36 24 OFFCURVE"
+"36 24 OFFCURVE",
+"69 -8 OFFCURVE",
+"115 -8 CURVE SMOOTH"
 );
 },
 {
@@ -28586,18 +28593,18 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"158 344 OFFCURVE",
-"168 355 OFFCURVE",
-"168 377 CURVE SMOOTH",
-"168 396 OFFCURVE",
-"158 406 OFFCURVE",
-"138 406 CURVE SMOOTH",
-"117 406 OFFCURVE",
-"107 396 OFFCURVE",
-"107 378 CURVE SMOOTH",
-"107 362 OFFCURVE",
-"123 344 OFFCURVE",
-"139 344 CURVE SMOOTH"
+"147 304 OFFCURVE",
+"157 315 OFFCURVE",
+"157 337 CURVE SMOOTH",
+"157 356 OFFCURVE",
+"147 366 OFFCURVE",
+"127 366 CURVE SMOOTH",
+"106 366 OFFCURVE",
+"96 356 OFFCURVE",
+"96 338 CURVE SMOOTH",
+"96 322 OFFCURVE",
+"112 304 OFFCURVE",
+"128 304 CURVE SMOOTH"
 );
 }
 );
@@ -28612,13 +28619,13 @@ unicode = 0069;
 {
 color = 3;
 glyphname = idotless;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-02-28 16:10:45 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{27, 0}";
+position = "{47, 40}";
 },
 {
 name = ogonek;
@@ -28626,7 +28633,7 @@ position = "{117, 0}";
 },
 {
 name = top;
-position = "{157, 244}";
+position = "{124, 187}";
 }
 );
 background = {
@@ -28733,7 +28740,7 @@ unicode = 0131;
 },
 {
 glyphname = iacute;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28752,7 +28759,7 @@ name = idotless;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28765,7 +28772,7 @@ unicode = 00ED;
 },
 {
 glyphname = ibreve;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28784,7 +28791,7 @@ name = idotless;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28797,7 +28804,7 @@ unicode = 012D;
 },
 {
 glyphname = icaron;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28816,7 +28823,7 @@ name = idotless;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28829,7 +28836,7 @@ unicode = 01D0;
 },
 {
 glyphname = icircumflex;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28848,7 +28855,7 @@ name = idotless;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28861,7 +28868,7 @@ unicode = 00EE;
 },
 {
 glyphname = idblgrave;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28880,7 +28887,7 @@ name = idotless;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28893,7 +28900,7 @@ unicode = 0209;
 },
 {
 glyphname = idieresis;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28912,7 +28919,7 @@ name = idotless;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28925,7 +28932,7 @@ unicode = 00EF;
 },
 {
 glyphname = idotaccent;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28944,7 +28951,7 @@ name = idotless;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28956,7 +28963,7 @@ rightKerningGroup = i;
 },
 {
 glyphname = idotbelow;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -28975,7 +28982,7 @@ name = i;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 27, 0}";
+transform = "{1, 0, 0, 1, -223, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -28988,7 +28995,7 @@ unicode = 1ECB;
 },
 {
 glyphname = igrave;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29007,7 +29014,7 @@ name = idotless;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29020,7 +29027,7 @@ unicode = 00EC;
 },
 {
 glyphname = ihookabove;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29039,7 +29046,7 @@ name = idotless;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29052,7 +29059,7 @@ unicode = 1EC9;
 },
 {
 glyphname = iinvertedbreve;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29071,7 +29078,7 @@ name = idotless;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29084,7 +29091,7 @@ unicode = 020B;
 },
 {
 glyphname = imacron;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29103,7 +29110,7 @@ name = idotless;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29116,7 +29123,7 @@ unicode = 012B;
 },
 {
 glyphname = iogonek;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29138,11 +29145,11 @@ name = idotless;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 117, 0}";
+transform = "{1, 0, 0, 1, -133, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29155,7 +29162,7 @@ unicode = 012F;
 },
 {
 glyphname = itilde;
-lastChange = "2022-02-14 13:04:57 +0000";
+lastChange = "2022-03-01 14:23:22 +0000";
 layers = (
 {
 background = {
@@ -29174,7 +29181,7 @@ name = idotless;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 157, 0}";
+transform = "{1, 0, 0, 1, -126, -57}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29186,98 +29193,12 @@ rightKerningGroup = i;
 unicode = 0129;
 },
 {
+color = 3;
 glyphname = j;
-lastChange = "2022-02-14 13:05:08 +0000";
+lastChange = "2022-03-01 15:41:22 +0000";
 layers = (
 {
 background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"-141 -501 OFFCURVE",
-"-55 -435 OFFCURVE",
-"20 -305 CURVE SMOOTH",
-"73 -215 OFFCURVE",
-"114 -105 OFFCURVE",
-"144 22 CURVE",
-"147 23 OFFCURVE",
-"151 23 OFFCURVE",
-"155 23 CURVE SMOOTH",
-"175 23 OFFCURVE",
-"193 7 OFFCURVE",
-"194 7 CURVE SMOOTH",
-"199 7 OFFCURVE",
-"201 10 OFFCURVE",
-"201 15 CURVE SMOOTH",
-"201 23 OFFCURVE",
-"195 31 OFFCURVE",
-"182 38 CURVE SMOOTH",
-"170 46 OFFCURVE",
-"160 50 OFFCURVE",
-"152 50 CURVE SMOOTH",
-"149 50 LINE",
-"169 148 OFFCURVE",
-"182 206 OFFCURVE",
-"189 221 CURVE",
-"165 212 OFFCURVE",
-"147 207 OFFCURVE",
-"137 207 CURVE",
-"126 202 OFFCURVE",
-"116 178 OFFCURVE",
-"108 134 CURVE SMOOTH",
-"97 48 LINE",
-"4 19 OFFCURVE",
-"-90 -36 OFFCURVE",
-"-185 -116 CURVE SMOOTH",
-"-297 -210 OFFCURVE",
-"-352 -298 OFFCURVE",
-"-352 -379 CURVE SMOOTH",
-"-352 -460 OFFCURVE",
-"-314 -501 OFFCURVE",
-"-239 -501 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"-304 -478 OFFCURVE",
-"-332 -448 OFFCURVE",
-"-332 -388 CURVE SMOOTH",
-"-332 -287 OFFCURVE",
-"-258 -187 OFFCURVE",
-"-110 -89 CURVE SMOOTH",
-"-6 -20 OFFCURVE",
-"60 18 OFFCURVE",
-"91 22 CURVE",
-"84 -75 OFFCURVE",
-"50 -179 OFFCURVE",
-"-13 -287 CURVE SMOOTH",
-"-86 -415 OFFCURVE",
-"-165 -478 OFFCURVE",
-"-251 -478 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"191 330 OFFCURVE",
-"214 344 OFFCURVE",
-"214 355 CURVE SMOOTH",
-"214 378 OFFCURVE",
-"202 389 OFFCURVE",
-"180 389 CURVE SMOOTH",
-"165 389 OFFCURVE",
-"158 378 OFFCURVE",
-"158 355 CURVE SMOOTH",
-"158 339 OFFCURVE",
-"165 330 OFFCURVE",
-"180 330 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
 paths = (
 {
 closed = 1;
@@ -29363,6 +29284,93 @@ nodes = (
 );
 }
 );
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"-141 -501 OFFCURVE",
+"-55 -435 OFFCURVE",
+"20 -305 CURVE SMOOTH",
+"73 -215 OFFCURVE",
+"114 -105 OFFCURVE",
+"144 22 CURVE",
+"147 23 OFFCURVE",
+"151 23 OFFCURVE",
+"155 23 CURVE SMOOTH",
+"175 23 OFFCURVE",
+"193 7 OFFCURVE",
+"194 7 CURVE SMOOTH",
+"199 7 OFFCURVE",
+"201 10 OFFCURVE",
+"201 15 CURVE SMOOTH",
+"201 23 OFFCURVE",
+"195 31 OFFCURVE",
+"182 38 CURVE SMOOTH",
+"170 46 OFFCURVE",
+"160 50 OFFCURVE",
+"152 50 CURVE SMOOTH",
+"149 50 LINE",
+"169 148 OFFCURVE",
+"182 206 OFFCURVE",
+"189 221 CURVE",
+"165 212 OFFCURVE",
+"147 207 OFFCURVE",
+"137 207 CURVE",
+"126 202 OFFCURVE",
+"114 178 OFFCURVE",
+"108 134 CURVE SMOOTH",
+"97 48 LINE",
+"4 19 OFFCURVE",
+"-90 -36 OFFCURVE",
+"-185 -116 CURVE SMOOTH",
+"-297 -210 OFFCURVE",
+"-352 -298 OFFCURVE",
+"-352 -387 CURVE SMOOTH",
+"-352 -460 OFFCURVE",
+"-314 -501 OFFCURVE",
+"-239 -501 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-291 -478 OFFCURVE",
+"-332 -452 OFFCURVE",
+"-332 -388 CURVE SMOOTH",
+"-332 -287 OFFCURVE",
+"-258 -187 OFFCURVE",
+"-110 -89 CURVE SMOOTH",
+"-6 -20 OFFCURVE",
+"60 18 OFFCURVE",
+"91 22 CURVE",
+"84 -75 OFFCURVE",
+"50 -179 OFFCURVE",
+"-13 -287 CURVE SMOOTH",
+"-86 -415 OFFCURVE",
+"-165 -478 OFFCURVE",
+"-239 -478 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 290 OFFCURVE",
+"204 304 OFFCURVE",
+"204 315 CURVE SMOOTH",
+"204 338 OFFCURVE",
+"192 349 OFFCURVE",
+"170 349 CURVE SMOOTH",
+"155 349 OFFCURVE",
+"148 338 OFFCURVE",
+"148 315 CURVE SMOOTH",
+"148 299 OFFCURVE",
+"155 290 OFFCURVE",
+"170 290 CURVE SMOOTH"
+);
+}
+);
 width = 205;
 }
 );
@@ -29374,7 +29382,7 @@ unicode = 006A;
 {
 color = 3;
 glyphname = jdotless;
-lastChange = "2022-02-14 13:05:08 +0000";
+lastChange = "2022-02-28 15:57:41 +0000";
 layers = (
 {
 anchors = (
@@ -29384,7 +29392,7 @@ position = "{-239, -501}";
 },
 {
 name = top;
-position = "{171, 244}";
+position = "{166, 204}";
 }
 );
 background = {
@@ -29535,7 +29543,7 @@ unicode = 0237;
 },
 {
 glyphname = jcircumflex;
-lastChange = "2022-02-14 13:05:08 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -29554,7 +29562,7 @@ name = jdotless;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -84, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -29800,7 +29808,7 @@ unicode = 006B;
 },
 {
 glyphname = kcommaaccent;
-lastChange = "2022-02-14 13:05:24 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -29819,7 +29827,7 @@ name = k;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 114, 0}";
+transform = "{1, 0, 0, 1, -136, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30009,13 +30017,13 @@ unicode = 0138;
 {
 color = 3;
 glyphname = l;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 16:11:36 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{76, 0}";
+position = "{96, 40}";
 },
 {
 name = center;
@@ -30023,7 +30031,7 @@ position = "{119, 400}";
 },
 {
 name = top;
-position = "{350, 613}";
+position = "{340, 573}";
 },
 {
 name = topright;
@@ -30170,7 +30178,7 @@ unicode = 006C;
 },
 {
 glyphname = lacute;
-lastChange = "2022-02-14 13:05:43 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -30188,8 +30196,8 @@ components = (
 name = l;
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 350, 369}";
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 90, 329}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30202,7 +30210,7 @@ unicode = 013A;
 },
 {
 glyphname = lcaron;
-lastChange = "2022-02-14 13:05:43 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -30221,7 +30229,7 @@ name = l;
 },
 {
 name = caroncomb.alt;
-transform = "{1, 0, 0, 1, 350, 0}";
+transform = "{1, 0, 0, 1, 100, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30234,7 +30242,7 @@ unicode = 013E;
 },
 {
 glyphname = lcommaaccent;
-lastChange = "2022-02-14 13:05:43 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -30253,7 +30261,7 @@ name = l;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 76, 0}";
+transform = "{1, 0, 0, 1, -154, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30380,7 +30388,7 @@ unicode = 0140;
 },
 {
 glyphname = lj;
-lastChange = "2022-02-14 13:05:48 +0000";
+lastChange = "2022-03-01 14:23:31 +0000";
 layers = (
 {
 background = {
@@ -30412,8 +30420,9 @@ rightKerningGroup = j;
 unicode = 01C9;
 },
 {
+color = 3;
 glyphname = lslash;
-lastChange = "2022-02-14 13:05:43 +0000";
+lastChange = "2022-03-01 10:54:52 +0000";
 layers = (
 {
 background = {
@@ -30427,16 +30436,98 @@ transform = "{0.98769, 0.15643, -0.15643, 0.98769, -68, -87}";
 }
 );
 };
-components = (
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
 {
-name = l;
+closed = 1;
+nodes = (
+"192 -12 OFFCURVE",
+"240 16 OFFCURVE",
+"297 89 CURVE",
+"302 97 OFFCURVE",
+"304 103 OFFCURVE",
+"304 107 CURVE SMOOTH",
+"304 110 OFFCURVE",
+"303 112 OFFCURVE",
+"301 112 CURVE SMOOTH",
+"300 112 OFFCURVE",
+"297 110 OFFCURVE",
+"293 106 CURVE SMOOTH",
+"248 50 OFFCURVE",
+"213 15 OFFCURVE",
+"156 15 CURVE SMOOTH",
+"108 15 OFFCURVE",
+"81 45 OFFCURVE",
+"73 105 CURVE",
+"121 155 OFFCURVE",
+"176 228 OFFCURVE",
+"239 327 CURVE SMOOTH",
+"313 441 OFFCURVE",
+"350 522 OFFCURVE",
+"350 570 CURVE SMOOTH",
+"350 583 LINE",
+"343 611 OFFCURVE",
+"331 624 OFFCURVE",
+"310 624 CURVE SMOOTH",
+"255 624 OFFCURVE",
+"195 568 OFFCURVE",
+"132 454 CURVE SMOOTH",
+"68 340 OFFCURVE",
+"36 234 OFFCURVE",
+"36 137 CURVE SMOOTH",
+"36 38 OFFCURVE",
+"69 -12 OFFCURVE",
+"137 -12 CURVE SMOOTH"
+);
 },
 {
-name = strokeshortcomb;
-transform = "{0.97815, 0.20791, -0.20791, 0.97815, 93, 522}";
+closed = 1;
+nodes = (
+"74 207 OFFCURVE",
+"100 303 OFFCURVE",
+"150 420 CURVE SMOOTH",
+"203 539 OFFCURVE",
+"250 598 OFFCURVE",
+"291 598 CURVE SMOOTH",
+"301 598 OFFCURVE",
+"307 588 OFFCURVE",
+"307 570 CURVE SMOOTH",
+"307 528 OFFCURVE",
+"276 451 OFFCURVE",
+"215 340 CURVE SMOOTH",
+"157 235 OFFCURVE",
+"110 165 OFFCURVE",
+"74 130 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"96 369 OFFCURVE",
+"122 378 OFFCURVE",
+"147 385 CURVE SMOOTH",
+"179 394 OFFCURVE",
+"364 446 OFFCURVE",
+"397 453 CURVE SMOOTH",
+"405 455 OFFCURVE",
+"406 464 OFFCURVE",
+"406 467 CURVE SMOOTH",
+"405 472 OFFCURVE",
+"352 468 OFFCURVE",
+"294 456 CURVE SMOOTH",
+"227 442 OFFCURVE",
+"152 418 OFFCURVE",
+"138 415 CURVE SMOOTH",
+"117 411 OFFCURVE",
+"59 395 OFFCURVE",
+"42 386 CURVE SMOOTH",
+"40 385 LINE",
+"43 377 OFFCURVE",
+"60 362 OFFCURVE",
+"66 363 CURVE SMOOTH"
+);
 }
 );
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
 width = 257;
 }
 );
@@ -30666,17 +30757,17 @@ unicode = 006D;
 {
 color = 3;
 glyphname = n;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 16:10:34 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{102, 0}";
+position = "{111, 40}";
 },
 {
 name = top;
-position = "{162, 244}";
+position = "{144, 184}";
 }
 );
 background = {
@@ -30826,7 +30917,7 @@ unicode = 006E;
 },
 {
 glyphname = nacute;
-lastChange = "2022-02-14 13:06:20 +0000";
+lastChange = "2022-03-01 14:25:51 +0000";
 layers = (
 {
 background = {
@@ -30845,7 +30936,7 @@ name = n;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 162, 0}";
+transform = "{1, 0, 0, 1, -106, -60}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30858,7 +30949,7 @@ unicode = 0144;
 },
 {
 glyphname = ncaron;
-lastChange = "2022-02-14 13:06:20 +0000";
+lastChange = "2022-03-01 14:25:51 +0000";
 layers = (
 {
 background = {
@@ -30877,7 +30968,7 @@ name = n;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 162, 0}";
+transform = "{1, 0, 0, 1, -106, -60}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30890,7 +30981,7 @@ unicode = 0148;
 },
 {
 glyphname = ncommaaccent;
-lastChange = "2022-02-14 13:06:20 +0000";
+lastChange = "2022-03-01 14:25:51 +0000";
 layers = (
 {
 background = {
@@ -30909,7 +31000,7 @@ name = n;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 102, 0}";
+transform = "{1, 0, 0, 1, -139, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -30919,71 +31010,6 @@ width = 323;
 leftKerningGroup = n;
 rightKerningGroup = n;
 unicode = 0146;
-},
-{
-glyphname = nj;
-lastChange = "2022-02-14 13:06:25 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 331, 0}";
-}
-);
-};
-components = (
-{
-name = n;
-},
-{
-name = j;
-transform = "{1, 0, 0, 1, 323, 0}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 528;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = j;
-unicode = 01CC;
-},
-{
-glyphname = ntilde;
-lastChange = "2022-02-14 13:06:20 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = n;
-},
-{
-name = tildecomb;
-}
-);
-};
-components = (
-{
-name = n;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 162, 0}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 323;
-}
-);
-leftKerningGroup = n;
-rightKerningGroup = n;
-unicode = 00F1;
 },
 {
 glyphname = eng;
@@ -31142,14 +31168,80 @@ leftKerningGroup = n;
 unicode = 014B;
 },
 {
+glyphname = nj;
+lastChange = "2022-02-14 13:06:25 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 331, 0}";
+}
+);
+};
+components = (
+{
+name = n;
+},
+{
+name = j;
+transform = "{1, 0, 0, 1, 323, 0}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 528;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = j;
+unicode = 01CC;
+},
+{
+glyphname = ntilde;
+lastChange = "2022-03-01 14:25:51 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+}
+);
+};
+components = (
+{
+name = n;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, -106, -60}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 323;
+}
+);
+leftKerningGroup = n;
+rightKerningGroup = n;
+unicode = 00F1;
+},
+{
+color = 3;
 glyphname = o;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-02-28 16:13:08 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{29, 0}";
+position = "{41, 40}";
 },
 {
 name = center;
@@ -31165,7 +31257,7 @@ position = "{81, 0}";
 },
 {
 name = top;
-position = "{171, 244}";
+position = "{154, 195}";
 }
 );
 background = {
@@ -31390,9 +31482,8 @@ rightKerningGroup = o;
 unicode = 006F;
 },
 {
-color = 3;
 glyphname = oacute;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31411,7 +31502,7 @@ name = o;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31424,7 +31515,7 @@ unicode = 00F3;
 },
 {
 glyphname = obreve;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31443,7 +31534,7 @@ name = o;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31457,7 +31548,7 @@ unicode = 014F;
 {
 color = 9;
 glyphname = ocaron;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 components = (
@@ -31466,7 +31557,7 @@ name = o;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31479,7 +31570,7 @@ unicode = 01D2;
 },
 {
 glyphname = ocircumflex;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31498,7 +31589,7 @@ name = o;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31511,7 +31602,7 @@ unicode = 00F4;
 },
 {
 glyphname = ocircumflexacute;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31530,7 +31621,7 @@ name = o;
 },
 {
 name = circumflexcomb_acutecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31543,7 +31634,7 @@ unicode = 1ED1;
 },
 {
 glyphname = ocircumflexdotbelow;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31565,11 +31656,11 @@ name = o;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 29, 0}";
+transform = "{1, 0, 0, 1, -209, 40}";
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31582,7 +31673,7 @@ unicode = 1ED9;
 },
 {
 glyphname = ocircumflexgrave;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31601,7 +31692,7 @@ name = o;
 },
 {
 name = circumflexcomb_gravecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31614,7 +31705,7 @@ unicode = 1ED3;
 },
 {
 glyphname = ocircumflexhookabove;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31633,7 +31724,7 @@ name = o;
 },
 {
 name = circumflexcomb_hookabovecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31646,7 +31737,7 @@ unicode = 1ED5;
 },
 {
 glyphname = ocircumflextilde;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31665,7 +31756,7 @@ name = o;
 },
 {
 name = circumflexcomb_tildecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31678,7 +31769,7 @@ unicode = 1ED7;
 },
 {
 glyphname = odblgrave;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31697,7 +31788,7 @@ name = o;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31710,7 +31801,7 @@ unicode = 020D;
 },
 {
 glyphname = odieresis;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31729,7 +31820,7 @@ name = o;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31743,7 +31834,7 @@ unicode = 00F6;
 {
 color = 3;
 glyphname = odieresismacron;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:28:48 +0000";
 layers = (
 {
 background = {
@@ -31765,12 +31856,12 @@ name = o;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 },
 {
 alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 181, 100}";
+transform = "{1, 0, 0, 1, -76, 41}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31784,7 +31875,7 @@ unicode = 022B;
 {
 color = 3;
 glyphname = odotaccentmacron;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:28:48 +0000";
 layers = (
 {
 background = {
@@ -31806,12 +31897,12 @@ name = o;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 },
 {
 alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 181, 99}";
+transform = "{1, 0, 0, 1, -76, 31}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31824,7 +31915,7 @@ unicode = 0231;
 },
 {
 glyphname = odotbelow;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31843,7 +31934,7 @@ name = o;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 29, 0}";
+transform = "{1, 0, 0, 1, -209, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31856,7 +31947,7 @@ unicode = 1ECD;
 },
 {
 glyphname = ograve;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31875,7 +31966,7 @@ name = o;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31888,7 +31979,7 @@ unicode = 00F2;
 },
 {
 glyphname = ohookabove;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31907,7 +31998,7 @@ name = o;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31920,7 +32011,7 @@ unicode = 1ECF;
 },
 {
 glyphname = ohorn;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31940,7 +32031,7 @@ name = o;
 },
 {
 name = horncomb;
-transform = "{1, 0, 0, 1, 161, -18}";
+transform = "{1, 0, 0, 1, -89, -18}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31953,7 +32044,7 @@ unicode = 01A1;
 },
 {
 glyphname = ohornacute;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -31972,7 +32063,7 @@ name = ohorn;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -31985,7 +32076,7 @@ unicode = 1EDB;
 },
 {
 glyphname = ohorndotbelow;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32004,7 +32095,7 @@ name = ohorn;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 29, 0}";
+transform = "{1, 0, 0, 1, -209, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32017,7 +32108,7 @@ unicode = 1EE3;
 },
 {
 glyphname = ohorngrave;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32036,7 +32127,7 @@ name = ohorn;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32049,7 +32140,7 @@ unicode = 1EDD;
 },
 {
 glyphname = ohornhookabove;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32068,7 +32159,7 @@ name = ohorn;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32081,7 +32172,7 @@ unicode = 1EDF;
 },
 {
 glyphname = ohorntilde;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 15:38:54 +0000";
 layers = (
 {
 background = {
@@ -32099,8 +32190,9 @@ components = (
 name = ohorn;
 },
 {
+alignment = -1;
 name = tildecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -116, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32113,7 +32205,7 @@ unicode = 1EE1;
 },
 {
 glyphname = ohungarumlaut;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32132,7 +32224,7 @@ name = o;
 },
 {
 name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32145,7 +32237,7 @@ unicode = 0151;
 },
 {
 glyphname = oinvertedbreve;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32164,7 +32256,7 @@ name = o;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32177,7 +32269,7 @@ unicode = 020F;
 },
 {
 glyphname = omacron;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32196,7 +32288,7 @@ name = o;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32209,7 +32301,7 @@ unicode = 014D;
 },
 {
 glyphname = oogonek;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32228,7 +32320,7 @@ name = o;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 81, 0}";
+transform = "{1, 0, 0, 1, -169, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32242,13 +32334,13 @@ unicode = 01EB;
 {
 color = 3;
 glyphname = oslash;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 15:39:37 +0000";
 layers = (
 {
 anchors = (
 {
 name = top;
-position = "{171, 244}";
+position = "{152, 204}";
 }
 );
 background = {
@@ -32256,138 +32348,138 @@ paths = (
 {
 closed = 1;
 nodes = (
-"30 -114 LINE",
-"33 -97 OFFCURVE",
-"37 -83 OFFCURVE",
-"41 -71 CURVE SMOOTH",
-"47 -53 OFFCURVE",
-"54 -33 OFFCURVE",
-"63 -13 CURVE",
-"68 -16 OFFCURVE",
-"75 -18 OFFCURVE",
-"82 -18 CURVE SMOOTH",
-"114 -18 OFFCURVE",
-"145 11 OFFCURVE",
-"175 68 CURVE",
-"190 56 OFFCURVE",
-"207 50 OFFCURVE",
-"225 50 CURVE SMOOTH",
-"261 50 OFFCURVE",
-"291 68 OFFCURVE",
-"317 104 CURVE SMOOTH",
-"320 108 OFFCURVE",
-"322 112 OFFCURVE",
-"322 116 CURVE SMOOTH",
-"322 118 OFFCURVE",
-"321 120 OFFCURVE",
-"320 121 CURVE SMOOTH",
-"317 126 OFFCURVE",
-"314 126 OFFCURVE",
-"310 121 CURVE SMOOTH",
-"279 84 OFFCURVE",
-"251 65 OFFCURVE",
-"224 65 CURVE SMOOTH",
-"207 65 OFFCURVE",
-"192 72 OFFCURVE",
-"181 85 CURVE",
-"199 127 OFFCURVE",
-"208 160 OFFCURVE",
-"208 184 CURVE SMOOTH",
-"208 193 OFFCURVE",
-"207 201 OFFCURVE",
-"205 207 CURVE",
-"236 248 OFFCURVE",
-"270 290 OFFCURVE",
-"307 331 CURVE",
-"308 333 OFFCURVE",
-"309 334 OFFCURVE",
-"309 335 CURVE SMOOTH",
-"309 336 OFFCURVE",
-"308 337 OFFCURVE",
-"304 337 CURVE SMOOTH",
-"298 337 OFFCURVE",
-"292 334 OFFCURVE",
-"284 327 CURVE",
-"262 302 OFFCURVE",
-"247 283 OFFCURVE",
-"235 267 CURVE SMOOTH",
-"199 219 LINE",
-"194 223 OFFCURVE",
-"187 226 OFFCURVE",
-"180 226 CURVE SMOOTH",
-"176 226 OFFCURVE",
-"172 225 OFFCURVE",
-"167 223 CURVE",
-"158 237 OFFCURVE",
-"147 244 OFFCURVE",
-"136 244 CURVE SMOOTH",
-"122 244 OFFCURVE",
-"105 223 OFFCURVE",
-"86 182 CURVE SMOOTH",
-"72 153 OFFCURVE",
-"62 127 OFFCURVE",
-"56 103 CURVE SMOOTH",
-"49 77 OFFCURVE",
-"45 55 OFFCURVE",
-"45 36 CURVE SMOOTH",
-"45 16 OFFCURVE",
-"49 1 OFFCURVE",
-"57 -8 CURVE",
-"43 -35 OFFCURVE",
-"33 -60 OFFCURVE",
-"27 -81 CURVE SMOOTH",
-"23 -93 OFFCURVE",
-"22 -100 OFFCURVE",
-"22 -103 CURVE SMOOTH",
-"22 -107 OFFCURVE",
-"27 -114 OFFCURVE",
-"29 -114 CURVE SMOOTH"
+"11 -114 LINE",
+"14 -97 OFFCURVE",
+"18 -83 OFFCURVE",
+"22 -71 CURVE SMOOTH",
+"28 -53 OFFCURVE",
+"35 -33 OFFCURVE",
+"44 -13 CURVE",
+"49 -16 OFFCURVE",
+"56 -18 OFFCURVE",
+"63 -18 CURVE SMOOTH",
+"95 -18 OFFCURVE",
+"126 11 OFFCURVE",
+"156 68 CURVE",
+"171 56 OFFCURVE",
+"188 50 OFFCURVE",
+"206 50 CURVE SMOOTH",
+"242 50 OFFCURVE",
+"272 68 OFFCURVE",
+"298 104 CURVE SMOOTH",
+"301 108 OFFCURVE",
+"303 112 OFFCURVE",
+"303 116 CURVE SMOOTH",
+"303 118 OFFCURVE",
+"302 120 OFFCURVE",
+"301 121 CURVE SMOOTH",
+"298 126 OFFCURVE",
+"295 126 OFFCURVE",
+"291 121 CURVE SMOOTH",
+"260 84 OFFCURVE",
+"232 65 OFFCURVE",
+"205 65 CURVE SMOOTH",
+"188 65 OFFCURVE",
+"173 72 OFFCURVE",
+"162 85 CURVE",
+"180 127 OFFCURVE",
+"189 160 OFFCURVE",
+"189 184 CURVE SMOOTH",
+"189 193 OFFCURVE",
+"188 201 OFFCURVE",
+"186 207 CURVE",
+"217 248 OFFCURVE",
+"251 290 OFFCURVE",
+"288 331 CURVE",
+"289 333 OFFCURVE",
+"290 334 OFFCURVE",
+"290 335 CURVE SMOOTH",
+"290 336 OFFCURVE",
+"289 337 OFFCURVE",
+"285 337 CURVE SMOOTH",
+"279 337 OFFCURVE",
+"273 334 OFFCURVE",
+"265 327 CURVE",
+"243 302 OFFCURVE",
+"228 283 OFFCURVE",
+"216 267 CURVE SMOOTH",
+"180 219 LINE",
+"175 223 OFFCURVE",
+"168 226 OFFCURVE",
+"161 226 CURVE SMOOTH",
+"157 226 OFFCURVE",
+"153 225 OFFCURVE",
+"148 223 CURVE",
+"139 237 OFFCURVE",
+"128 244 OFFCURVE",
+"117 244 CURVE SMOOTH",
+"103 244 OFFCURVE",
+"86 223 OFFCURVE",
+"67 182 CURVE SMOOTH",
+"53 153 OFFCURVE",
+"43 127 OFFCURVE",
+"37 103 CURVE SMOOTH",
+"30 77 OFFCURVE",
+"26 55 OFFCURVE",
+"26 36 CURVE SMOOTH",
+"26 16 OFFCURVE",
+"30 1 OFFCURVE",
+"38 -8 CURVE",
+"24 -35 OFFCURVE",
+"14 -60 OFFCURVE",
+"8 -81 CURVE SMOOTH",
+"4 -93 OFFCURVE",
+"3 -100 OFFCURVE",
+"3 -103 CURVE SMOOTH",
+"3 -107 OFFCURVE",
+"8 -114 OFFCURVE",
+"10 -114 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"87 10 OFFCURVE",
-"81 19 OFFCURVE",
-"81 37 CURVE SMOOTH",
-"81 49 OFFCURVE",
-"85 69 OFFCURVE",
-"94 98 CURVE SMOOTH",
-"102 127 OFFCURVE",
-"111 144 OFFCURVE",
-"118 150 CURVE",
-"122 123 OFFCURVE",
-"136 100 OFFCURVE",
-"159 80 CURVE",
-"154 67 OFFCURVE",
-"146 54 OFFCURVE",
-"135 39 CURVE SMOOTH",
-"120 20 OFFCURVE",
-"108 10 OFFCURVE",
-"100 10 CURVE SMOOTH"
+"68 10 OFFCURVE",
+"62 19 OFFCURVE",
+"62 37 CURVE SMOOTH",
+"62 49 OFFCURVE",
+"66 69 OFFCURVE",
+"75 98 CURVE SMOOTH",
+"83 127 OFFCURVE",
+"92 144 OFFCURVE",
+"99 150 CURVE",
+"103 123 OFFCURVE",
+"117 100 OFFCURVE",
+"140 80 CURVE",
+"135 67 OFFCURVE",
+"127 54 OFFCURVE",
+"116 39 CURVE SMOOTH",
+"101 20 OFFCURVE",
+"89 10 OFFCURVE",
+"81 10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"159 103 OFFCURVE",
-"153 113 OFFCURVE",
-"148 133 CURVE SMOOTH",
-"143 148 OFFCURVE",
-"141 161 OFFCURVE",
-"141 170 CURVE SMOOTH",
-"141 194 OFFCURVE",
-"148 207 OFFCURVE",
-"161 207 CURVE SMOOTH",
-"174 207 OFFCURVE",
-"181 195 OFFCURVE",
-"181 173 CURVE SMOOTH",
-"181 161 OFFCURVE",
-"179 146 OFFCURVE",
-"176 128 CURVE SMOOTH",
-"172 108 OFFCURVE",
-"168 105 OFFCURVE",
-"165 102 CURVE"
+"140 103 OFFCURVE",
+"134 113 OFFCURVE",
+"129 133 CURVE SMOOTH",
+"124 148 OFFCURVE",
+"122 161 OFFCURVE",
+"122 170 CURVE SMOOTH",
+"122 194 OFFCURVE",
+"129 207 OFFCURVE",
+"142 207 CURVE SMOOTH",
+"155 207 OFFCURVE",
+"162 195 OFFCURVE",
+"162 173 CURVE SMOOTH",
+"162 161 OFFCURVE",
+"160 146 OFFCURVE",
+"157 128 CURVE SMOOTH",
+"153 108 OFFCURVE",
+"149 105 OFFCURVE",
+"146 102 CURVE"
 );
 }
 );
@@ -32397,142 +32489,142 @@ paths = (
 {
 closed = 1;
 nodes = (
-"30 -114 LINE",
-"33 -97 OFFCURVE",
-"37 -83 OFFCURVE",
-"41 -71 CURVE SMOOTH",
-"47 -53 OFFCURVE",
-"54 -33 OFFCURVE",
-"63 -13 CURVE",
-"68 -16 OFFCURVE",
-"75 -18 OFFCURVE",
-"82 -18 CURVE SMOOTH",
-"114 -18 OFFCURVE",
-"145 11 OFFCURVE",
-"175 68 CURVE",
-"190 56 OFFCURVE",
-"207 50 OFFCURVE",
-"225 50 CURVE SMOOTH",
-"261 50 OFFCURVE",
-"291 68 OFFCURVE",
-"317 104 CURVE SMOOTH",
-"320 108 OFFCURVE",
-"322 112 OFFCURVE",
-"322 116 CURVE SMOOTH",
-"322 118 OFFCURVE",
-"321 120 OFFCURVE",
-"320 121 CURVE SMOOTH",
-"317 126 OFFCURVE",
-"314 126 OFFCURVE",
-"310 121 CURVE SMOOTH",
-"279 84 OFFCURVE",
-"251 65 OFFCURVE",
-"224 65 CURVE SMOOTH",
-"207 65 OFFCURVE",
-"192 72 OFFCURVE",
-"181 85 CURVE",
-"199 127 OFFCURVE",
-"208 160 OFFCURVE",
-"208 184 CURVE SMOOTH",
-"208 193 OFFCURVE",
-"207 201 OFFCURVE",
-"205 207 CURVE",
-"236 248 OFFCURVE",
-"270 290 OFFCURVE",
-"307 331 CURVE",
-"308 333 OFFCURVE",
-"309 334 OFFCURVE",
-"309 335 CURVE SMOOTH",
-"309 336 OFFCURVE",
-"308 337 OFFCURVE",
-"304 337 CURVE SMOOTH",
-"298 337 OFFCURVE",
-"292 334 OFFCURVE",
-"284 327 CURVE",
-"262 302 OFFCURVE",
-"247 283 OFFCURVE",
-"235 267 CURVE SMOOTH",
-"199 219 LINE",
-"194 223 OFFCURVE",
-"187 226 OFFCURVE",
-"180 226 CURVE SMOOTH",
-"176 226 OFFCURVE",
-"172 225 OFFCURVE",
-"167 223 CURVE",
-"158 237 OFFCURVE",
-"147 244 OFFCURVE",
-"136 244 CURVE SMOOTH",
-"122 244 OFFCURVE",
-"105 223 OFFCURVE",
-"86 182 CURVE SMOOTH",
-"72 153 OFFCURVE",
-"62 127 OFFCURVE",
-"56 103 CURVE SMOOTH",
-"49 77 OFFCURVE",
-"45 55 OFFCURVE",
-"45 36 CURVE SMOOTH",
-"45 16 OFFCURVE",
-"49 1 OFFCURVE",
-"57 -8 CURVE",
-"43 -35 OFFCURVE",
-"33 -60 OFFCURVE",
-"27 -81 CURVE SMOOTH",
-"23 -93 OFFCURVE",
-"22 -100 OFFCURVE",
-"22 -103 CURVE SMOOTH",
-"22 -107 OFFCURVE",
-"27 -114 OFFCURVE",
-"29 -114 CURVE SMOOTH"
+"11 -114 LINE",
+"14 -97 OFFCURVE",
+"18 -83 OFFCURVE",
+"22 -71 CURVE SMOOTH",
+"28 -53 OFFCURVE",
+"35 -33 OFFCURVE",
+"44 -13 CURVE",
+"49 -16 OFFCURVE",
+"56 -18 OFFCURVE",
+"63 -18 CURVE SMOOTH",
+"95 -18 OFFCURVE",
+"126 11 OFFCURVE",
+"156 68 CURVE",
+"171 56 OFFCURVE",
+"188 50 OFFCURVE",
+"206 50 CURVE SMOOTH",
+"242 50 OFFCURVE",
+"272 68 OFFCURVE",
+"298 104 CURVE SMOOTH",
+"301 108 OFFCURVE",
+"303 112 OFFCURVE",
+"303 116 CURVE SMOOTH",
+"303 118 OFFCURVE",
+"302 120 OFFCURVE",
+"301 121 CURVE SMOOTH",
+"298 126 OFFCURVE",
+"295 126 OFFCURVE",
+"291 121 CURVE SMOOTH",
+"260 84 OFFCURVE",
+"232 65 OFFCURVE",
+"205 65 CURVE SMOOTH",
+"188 65 OFFCURVE",
+"173 72 OFFCURVE",
+"162 85 CURVE",
+"180 127 OFFCURVE",
+"189 160 OFFCURVE",
+"189 184 CURVE SMOOTH",
+"189 193 OFFCURVE",
+"188 201 OFFCURVE",
+"186 207 CURVE",
+"217 248 OFFCURVE",
+"251 290 OFFCURVE",
+"288 331 CURVE",
+"289 333 OFFCURVE",
+"290 334 OFFCURVE",
+"290 335 CURVE SMOOTH",
+"290 336 OFFCURVE",
+"289 337 OFFCURVE",
+"285 337 CURVE SMOOTH",
+"279 337 OFFCURVE",
+"273 334 OFFCURVE",
+"265 327 CURVE",
+"243 302 OFFCURVE",
+"228 283 OFFCURVE",
+"216 267 CURVE SMOOTH",
+"180 219 LINE",
+"175 223 OFFCURVE",
+"168 226 OFFCURVE",
+"161 226 CURVE SMOOTH",
+"157 226 OFFCURVE",
+"153 225 OFFCURVE",
+"148 223 CURVE",
+"139 237 OFFCURVE",
+"128 244 OFFCURVE",
+"117 244 CURVE SMOOTH",
+"103 244 OFFCURVE",
+"86 223 OFFCURVE",
+"67 182 CURVE SMOOTH",
+"53 153 OFFCURVE",
+"43 127 OFFCURVE",
+"37 103 CURVE SMOOTH",
+"30 77 OFFCURVE",
+"26 55 OFFCURVE",
+"26 36 CURVE SMOOTH",
+"26 16 OFFCURVE",
+"30 1 OFFCURVE",
+"38 -8 CURVE",
+"24 -35 OFFCURVE",
+"14 -60 OFFCURVE",
+"8 -81 CURVE SMOOTH",
+"4 -93 OFFCURVE",
+"3 -100 OFFCURVE",
+"3 -103 CURVE SMOOTH",
+"3 -107 OFFCURVE",
+"8 -114 OFFCURVE",
+"10 -114 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"87 10 OFFCURVE",
-"81 19 OFFCURVE",
-"81 37 CURVE SMOOTH",
-"81 49 OFFCURVE",
-"85 69 OFFCURVE",
-"94 98 CURVE SMOOTH",
-"102 127 OFFCURVE",
-"111 144 OFFCURVE",
-"118 150 CURVE",
-"122 123 OFFCURVE",
-"136 100 OFFCURVE",
-"159 80 CURVE",
-"154 67 OFFCURVE",
-"146 54 OFFCURVE",
-"135 39 CURVE SMOOTH",
-"120 20 OFFCURVE",
-"108 10 OFFCURVE",
-"100 10 CURVE SMOOTH"
+"68 10 OFFCURVE",
+"62 19 OFFCURVE",
+"62 37 CURVE SMOOTH",
+"62 49 OFFCURVE",
+"66 69 OFFCURVE",
+"75 98 CURVE SMOOTH",
+"83 127 OFFCURVE",
+"92 144 OFFCURVE",
+"99 150 CURVE",
+"103 123 OFFCURVE",
+"117 100 OFFCURVE",
+"140 80 CURVE",
+"135 67 OFFCURVE",
+"127 54 OFFCURVE",
+"116 39 CURVE SMOOTH",
+"101 20 OFFCURVE",
+"89 10 OFFCURVE",
+"81 10 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"159 103 OFFCURVE",
-"153 113 OFFCURVE",
-"148 133 CURVE SMOOTH",
-"143 148 OFFCURVE",
-"141 161 OFFCURVE",
-"141 170 CURVE SMOOTH",
-"141 194 OFFCURVE",
-"148 207 OFFCURVE",
-"161 207 CURVE SMOOTH",
-"174 207 OFFCURVE",
-"181 195 OFFCURVE",
-"181 173 CURVE SMOOTH",
-"181 161 OFFCURVE",
-"179 146 OFFCURVE",
-"176 128 CURVE SMOOTH",
-"172 108 OFFCURVE",
-"168 105 OFFCURVE",
-"165 102 CURVE"
+"140 103 OFFCURVE",
+"134 113 OFFCURVE",
+"129 133 CURVE SMOOTH",
+"124 148 OFFCURVE",
+"122 161 OFFCURVE",
+"122 170 CURVE SMOOTH",
+"122 194 OFFCURVE",
+"129 207 OFFCURVE",
+"142 207 CURVE SMOOTH",
+"155 207 OFFCURVE",
+"162 195 OFFCURVE",
+"162 173 CURVE SMOOTH",
+"162 161 OFFCURVE",
+"160 146 OFFCURVE",
+"157 128 CURVE SMOOTH",
+"153 108 OFFCURVE",
+"149 105 OFFCURVE",
+"146 102 CURVE"
 );
 }
 );
-width = 264;
+width = 245;
 }
 );
 leftKerningGroup = o;
@@ -32542,7 +32634,7 @@ unicode = 00F8;
 },
 {
 glyphname = oslashacute;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 15:39:39 +0000";
 layers = (
 {
 background = {
@@ -32561,11 +32653,11 @@ name = oslash;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -98, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 264;
+width = 245;
 }
 );
 leftKerningGroup = o;
@@ -32574,7 +32666,7 @@ unicode = 01FF;
 },
 {
 glyphname = otilde;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32593,7 +32685,7 @@ name = o;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32606,7 +32698,7 @@ unicode = 00F5;
 },
 {
 glyphname = otildemacron;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-03-01 14:27:43 +0000";
 layers = (
 {
 background = {
@@ -32625,7 +32717,7 @@ name = o;
 },
 {
 name = tildecomb_macroncomb;
-transform = "{1, 0, 0, 1, 171, 0}";
+transform = "{1, 0, 0, 1, -96, -49}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -32637,8 +32729,9 @@ rightKerningGroup = o;
 unicode = 022D;
 },
 {
+color = 3;
 glyphname = oe;
-lastChange = "2022-02-14 13:07:31 +0000";
+lastChange = "2022-02-28 20:05:02 +0000";
 layers = (
 {
 background = {
@@ -32646,267 +32739,272 @@ paths = (
 {
 closed = 1;
 nodes = (
-"82 -13 OFFCURVE",
-"104 9 OFFCURVE",
-"125 51 CURVE",
-"130 14 OFFCURVE",
-"150 -5 OFFCURVE",
-"186 -5 CURVE SMOOTH",
-"209 -5 OFFCURVE",
-"235 3 OFFCURVE",
-"263 20 CURVE SMOOTH",
-"290 35 OFFCURVE",
-"310 53 OFFCURVE",
-"325 73 CURVE SMOOTH",
-"326 74 OFFCURVE",
-"327 76 OFFCURVE",
-"327 77 CURVE SMOOTH",
-"327 80 OFFCURVE",
-"326 81 OFFCURVE",
-"323 81 CURVE",
-"323 81 OFFCURVE",
-"309 69 OFFCURVE",
-"283 47 CURVE SMOOTH",
-"257 24 OFFCURVE",
-"232 14 OFFCURVE",
-"209 14 CURVE SMOOTH",
-"173 14 OFFCURVE",
-"154 28 OFFCURVE",
-"154 59 CURVE SMOOTH",
-"154 63 OFFCURVE",
-"155 68 OFFCURVE",
-"156 73 CURVE",
-"172 79 OFFCURVE",
-"188 91 OFFCURVE",
-"207 109 CURVE SMOOTH",
-"226 130 OFFCURVE",
-"236 148 OFFCURVE",
-"236 163 CURVE SMOOTH",
-"236 175 OFFCURVE",
-"226 187 OFFCURVE",
-"215 187 CURVE SMOOTH",
-"190 187 OFFCURVE",
-"168 172 OFFCURVE",
-"149 141 CURVE",
-"146 156 OFFCURVE",
-"141 164 OFFCURVE",
-"130 164 CURVE SMOOTH",
-"127 164 OFFCURVE",
-"124 163 OFFCURVE",
-"121 162 CURVE",
-"114 172 OFFCURVE",
-"106 177 OFFCURVE",
-"98 177 CURVE SMOOTH",
-"88 177 OFFCURVE",
-"76 162 OFFCURVE",
-"62 132 CURVE SMOOTH",
-"42 89 OFFCURVE",
-"32 54 OFFCURVE",
-"32 26 CURVE SMOOTH",
-"32 0 OFFCURVE",
-"41 -13 OFFCURVE",
-"60 -13 CURVE SMOOTH"
+"76 -13 OFFCURVE",
+"98 9 OFFCURVE",
+"119 51 CURVE",
+"124 14 OFFCURVE",
+"144 -5 OFFCURVE",
+"180 -5 CURVE SMOOTH",
+"203 -5 OFFCURVE",
+"229 3 OFFCURVE",
+"257 20 CURVE SMOOTH",
+"284 35 OFFCURVE",
+"304 53 OFFCURVE",
+"319 73 CURVE SMOOTH",
+"320 74 OFFCURVE",
+"321 76 OFFCURVE",
+"321 77 CURVE SMOOTH",
+"321 80 OFFCURVE",
+"320 81 OFFCURVE",
+"317 81 CURVE",
+"277 47 LINE SMOOTH",
+"251 24 OFFCURVE",
+"226 14 OFFCURVE",
+"203 14 CURVE SMOOTH",
+"167 14 OFFCURVE",
+"148 28 OFFCURVE",
+"148 59 CURVE SMOOTH",
+"148 63 OFFCURVE",
+"149 68 OFFCURVE",
+"150 73 CURVE",
+"166 79 OFFCURVE",
+"182 91 OFFCURVE",
+"201 109 CURVE SMOOTH",
+"220 130 OFFCURVE",
+"230 148 OFFCURVE",
+"230 163 CURVE SMOOTH",
+"230 175 OFFCURVE",
+"220 187 OFFCURVE",
+"209 187 CURVE SMOOTH",
+"184 187 OFFCURVE",
+"162 172 OFFCURVE",
+"143 141 CURVE",
+"140 156 OFFCURVE",
+"135 164 OFFCURVE",
+"124 164 CURVE SMOOTH",
+"121 164 OFFCURVE",
+"118 163 OFFCURVE",
+"115 162 CURVE",
+"108 172 OFFCURVE",
+"100 177 OFFCURVE",
+"92 177 CURVE SMOOTH",
+"82 177 OFFCURVE",
+"70 162 OFFCURVE",
+"56 132 CURVE SMOOTH",
+"36 89 OFFCURVE",
+"26 54 OFFCURVE",
+"26 26 CURVE SMOOTH",
+"26 0 OFFCURVE",
+"35 -13 OFFCURVE",
+"54 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"63 8 OFFCURVE",
-"59 14 OFFCURVE",
-"59 26 CURVE SMOOTH",
-"59 35 OFFCURVE",
-"61 50 OFFCURVE",
-"68 70 CURVE SMOOTH",
-"75 92 OFFCURVE",
-"80 104 OFFCURVE",
-"85 108 CURVE",
-"88 89 OFFCURVE",
-"98 72 OFFCURVE",
-"115 58 CURVE",
-"112 49 OFFCURVE",
-"106 39 OFFCURVE",
-"98 28 CURVE SMOOTH",
-"87 15 OFFCURVE",
-"79 8 OFFCURVE",
-"72 8 CURVE SMOOTH"
+"57 8 OFFCURVE",
+"53 14 OFFCURVE",
+"53 26 CURVE SMOOTH",
+"53 35 OFFCURVE",
+"55 50 OFFCURVE",
+"62 70 CURVE SMOOTH",
+"69 92 OFFCURVE",
+"74 104 OFFCURVE",
+"79 108 CURVE",
+"82 89 OFFCURVE",
+"92 72 OFFCURVE",
+"109 58 CURVE",
+"106 49 OFFCURVE",
+"100 39 OFFCURVE",
+"92 28 CURVE SMOOTH",
+"81 15 OFFCURVE",
+"73 8 OFFCURVE",
+"66 8 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
+"107 71 OFFCURVE",
+"103 79 OFFCURVE",
+"100 94 CURVE SMOOTH",
+"97 106 OFFCURVE",
+"96 116 OFFCURVE",
+"96 123 CURVE SMOOTH",
+"96 141 OFFCURVE",
+"101 149 OFFCURVE",
+"110 149 CURVE SMOOTH",
+"120 149 OFFCURVE",
+"125 141 OFFCURVE",
+"125 125 CURVE SMOOTH",
+"125 117 OFFCURVE",
+"123 105 OFFCURVE",
+"120 89 CURVE SMOOTH",
+"117 74 OFFCURVE",
 "113 71 OFFCURVE",
-"109 79 OFFCURVE",
-"106 94 CURVE SMOOTH",
-"103 106 OFFCURVE",
-"102 116 OFFCURVE",
-"102 123 CURVE SMOOTH",
-"102 141 OFFCURVE",
-"107 149 OFFCURVE",
-"116 149 CURVE SMOOTH",
-"126 149 OFFCURVE",
-"131 141 OFFCURVE",
-"131 125 CURVE SMOOTH",
-"131 117 OFFCURVE",
-"129 105 OFFCURVE",
-"126 89 CURVE SMOOTH",
-"123 74 OFFCURVE",
-"119 71 OFFCURVE",
-"118 70 CURVE"
+"112 70 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"161 99 OFFCURVE",
-"167 114 OFFCURVE",
-"177 133 CURVE SMOOTH",
-"187 155 OFFCURVE",
-"197 167 OFFCURVE",
-"205 167 CURVE SMOOTH",
-"212 167 OFFCURVE",
-"215 163 OFFCURVE",
-"215 156 CURVE SMOOTH",
-"215 132 OFFCURVE",
-"183 100 OFFCURVE",
-"159 88 CURVE"
+"155 99 OFFCURVE",
+"161 114 OFFCURVE",
+"171 133 CURVE SMOOTH",
+"181 155 OFFCURVE",
+"191 167 OFFCURVE",
+"199 167 CURVE SMOOTH",
+"206 167 OFFCURVE",
+"209 163 OFFCURVE",
+"209 156 CURVE SMOOTH",
+"209 132 OFFCURVE",
+"177 100 OFFCURVE",
+"153 88 CURVE"
 );
 }
 );
 };
+guideLines = (
+{
+position = "{74, 259}";
+}
+);
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
 paths = (
 {
 closed = 1;
 nodes = (
-"82 -13 OFFCURVE",
-"104 9 OFFCURVE",
-"125 51 CURVE",
-"130 14 OFFCURVE",
-"150 -5 OFFCURVE",
-"186 -5 CURVE SMOOTH",
-"209 -5 OFFCURVE",
-"235 3 OFFCURVE",
-"263 20 CURVE SMOOTH",
-"290 35 OFFCURVE",
-"310 53 OFFCURVE",
-"325 73 CURVE SMOOTH",
-"326 74 OFFCURVE",
-"327 76 OFFCURVE",
-"327 77 CURVE SMOOTH",
-"327 80 OFFCURVE",
-"326 81 OFFCURVE",
-"323 81 CURVE",
-"283 47 LINE SMOOTH",
-"257 24 OFFCURVE",
-"232 14 OFFCURVE",
-"209 14 CURVE SMOOTH",
-"173 14 OFFCURVE",
-"154 28 OFFCURVE",
-"154 59 CURVE SMOOTH",
-"154 63 OFFCURVE",
-"155 68 OFFCURVE",
-"156 73 CURVE",
-"172 79 OFFCURVE",
-"188 91 OFFCURVE",
-"207 109 CURVE SMOOTH",
-"226 130 OFFCURVE",
-"236 148 OFFCURVE",
-"236 163 CURVE SMOOTH",
-"236 175 OFFCURVE",
-"226 187 OFFCURVE",
-"215 187 CURVE SMOOTH",
-"190 187 OFFCURVE",
-"168 172 OFFCURVE",
-"149 141 CURVE",
-"146 156 OFFCURVE",
-"141 164 OFFCURVE",
-"130 164 CURVE SMOOTH",
-"127 164 OFFCURVE",
-"124 163 OFFCURVE",
-"121 162 CURVE",
-"114 172 OFFCURVE",
-"106 177 OFFCURVE",
-"98 177 CURVE SMOOTH",
-"88 177 OFFCURVE",
-"76 162 OFFCURVE",
-"62 132 CURVE SMOOTH",
-"42 89 OFFCURVE",
-"32 54 OFFCURVE",
-"32 26 CURVE SMOOTH",
-"32 0 OFFCURVE",
-"41 -13 OFFCURVE",
-"60 -13 CURVE SMOOTH"
+"94 -13 OFFCURVE",
+"124 17 OFFCURVE",
+"152 74 CURVE",
+"159 24 OFFCURVE",
+"186 -2 OFFCURVE",
+"235 -2 CURVE SMOOTH",
+"267 -2 OFFCURVE",
+"302 9 OFFCURVE",
+"340 32 CURVE SMOOTH",
+"377 52 OFFCURVE",
+"404 77 OFFCURVE",
+"424 104 CURVE SMOOTH",
+"426 105 OFFCURVE",
+"427 108 OFFCURVE",
+"427 109 CURVE SMOOTH",
+"427 113 OFFCURVE",
+"426 115 OFFCURVE",
+"422 115 CURVE",
+"367 69 LINE SMOOTH",
+"332 39 OFFCURVE",
+"298 24 OFFCURVE",
+"267 24 CURVE SMOOTH",
+"218 24 OFFCURVE",
+"192 43 OFFCURVE",
+"192 85 CURVE SMOOTH",
+"192 90 OFFCURVE",
+"193 97 OFFCURVE",
+"195 104 CURVE",
+"216 112 OFFCURVE",
+"238 128 OFFCURVE",
+"264 153 CURVE SMOOTH",
+"290 181 OFFCURVE",
+"303 206 OFFCURVE",
+"303 226 CURVE SMOOTH",
+"303 243 OFFCURVE",
+"290 259 OFFCURVE",
+"275 259 CURVE SMOOTH",
+"241 259 OFFCURVE",
+"211 239 OFFCURVE",
+"185 196 CURVE",
+"181 217 OFFCURVE",
+"174 228 OFFCURVE",
+"159 228 CURVE SMOOTH",
+"155 228 OFFCURVE",
+"151 226 OFFCURVE",
+"147 225 CURVE",
+"138 239 OFFCURVE",
+"127 245 OFFCURVE",
+"116 245 CURVE SMOOTH",
+"102 245 OFFCURVE",
+"86 225 OFFCURVE",
+"67 184 CURVE SMOOTH",
+"40 126 OFFCURVE",
+"26 78 OFFCURVE",
+"26 40 CURVE SMOOTH",
+"26 5 OFFCURVE",
+"38 -13 OFFCURVE",
+"64 -13 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"63 8 OFFCURVE",
-"59 14 OFFCURVE",
-"59 26 CURVE SMOOTH",
-"59 35 OFFCURVE",
-"61 50 OFFCURVE",
-"68 70 CURVE SMOOTH",
-"75 92 OFFCURVE",
-"80 104 OFFCURVE",
-"85 108 CURVE",
-"88 89 OFFCURVE",
-"98 72 OFFCURVE",
-"115 58 CURVE",
-"112 49 OFFCURVE",
-"106 39 OFFCURVE",
-"98 28 CURVE SMOOTH",
-"87 15 OFFCURVE",
-"79 8 OFFCURVE",
-"72 8 CURVE SMOOTH"
+"68 16 OFFCURVE",
+"63 24 OFFCURVE",
+"63 40 CURVE SMOOTH",
+"63 52 OFFCURVE",
+"65 73 OFFCURVE",
+"75 100 CURVE SMOOTH",
+"84 130 OFFCURVE",
+"91 146 OFFCURVE",
+"98 152 CURVE",
+"102 126 OFFCURVE",
+"116 103 OFFCURVE",
+"139 84 CURVE",
+"135 71 OFFCURVE",
+"127 58 OFFCURVE",
+"116 43 CURVE SMOOTH",
+"101 25 OFFCURVE",
+"90 16 OFFCURVE",
+"80 16 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"113 71 OFFCURVE",
-"109 79 OFFCURVE",
-"106 94 CURVE SMOOTH",
-"103 106 OFFCURVE",
-"102 116 OFFCURVE",
-"102 123 CURVE SMOOTH",
-"102 141 OFFCURVE",
-"107 149 OFFCURVE",
-"116 149 CURVE SMOOTH",
-"126 149 OFFCURVE",
-"131 141 OFFCURVE",
-"131 125 CURVE SMOOTH",
-"131 117 OFFCURVE",
-"129 105 OFFCURVE",
-"126 89 CURVE SMOOTH",
-"123 74 OFFCURVE",
-"119 71 OFFCURVE",
-"118 70 CURVE"
+"136 101 OFFCURVE",
+"131 112 OFFCURVE",
+"127 133 CURVE SMOOTH",
+"123 149 OFFCURVE",
+"121 162 OFFCURVE",
+"121 172 CURVE SMOOTH",
+"121 196 OFFCURVE",
+"128 207 OFFCURVE",
+"140 207 CURVE SMOOTH",
+"154 207 OFFCURVE",
+"161 196 OFFCURVE",
+"161 175 CURVE SMOOTH",
+"161 164 OFFCURVE",
+"158 147 OFFCURVE",
+"154 126 CURVE SMOOTH",
+"150 105 OFFCURVE",
+"144 101 OFFCURVE",
+"143 100 CURVE"
 );
 },
 {
 closed = 1;
 nodes = (
-"161 99 OFFCURVE",
-"167 114 OFFCURVE",
-"177 133 CURVE SMOOTH",
-"187 155 OFFCURVE",
-"197 167 OFFCURVE",
-"205 167 CURVE SMOOTH",
-"212 167 OFFCURVE",
-"215 163 OFFCURVE",
-"215 156 CURVE SMOOTH",
-"215 132 OFFCURVE",
-"183 100 OFFCURVE",
-"159 88 CURVE"
+"201 139 OFFCURVE",
+"210 160 OFFCURVE",
+"223 186 CURVE SMOOTH",
+"237 215 OFFCURVE",
+"250 232 OFFCURVE",
+"261 232 CURVE SMOOTH",
+"271 232 OFFCURVE",
+"275 226 OFFCURVE",
+"275 217 CURVE SMOOTH",
+"275 184 OFFCURVE",
+"231 141 OFFCURVE",
+"199 124 CURVE"
 );
 }
 );
-width = 289;
+width = 377;
 }
 );
 leftKerningGroup = o;
+leftMetricsKey = o;
 note = oe;
+rightMetricsKey = e;
 unicode = 0153;
 },
 {
@@ -33629,17 +33727,17 @@ unicode = 0071;
 {
 color = 3;
 glyphname = r;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 20:06:02 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{37, 0}";
+position = "{57, 40}";
 },
 {
 name = top;
-position = "{229, 284}";
+position = "{229, 269}";
 }
 );
 background = {
@@ -33831,7 +33929,7 @@ unicode = 0072;
 },
 {
 glyphname = racute;
-lastChange = "2022-02-14 13:07:55 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -33850,7 +33948,7 @@ name = r;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 229, 40}";
+transform = "{1, 0, 0, 1, -21, 25}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -33863,7 +33961,7 @@ unicode = 0155;
 },
 {
 glyphname = rcaron;
-lastChange = "2022-02-14 13:07:55 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -33882,7 +33980,7 @@ name = r;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 229, 40}";
+transform = "{1, 0, 0, 1, -21, 25}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -33895,7 +33993,7 @@ unicode = 0159;
 },
 {
 glyphname = rcommaaccent;
-lastChange = "2022-02-14 13:07:55 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -33914,7 +34012,7 @@ name = r;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 37, 0}";
+transform = "{1, 0, 0, 1, -193, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -33927,7 +34025,7 @@ unicode = 0157;
 },
 {
 glyphname = rdblgrave;
-lastChange = "2022-02-14 13:07:55 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -33946,7 +34044,7 @@ name = r;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 229, 40}";
+transform = "{1, 0, 0, 1, -21, 25}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -33959,7 +34057,7 @@ unicode = 0211;
 },
 {
 glyphname = rinvertedbreve;
-lastChange = "2022-02-14 13:07:55 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -33978,7 +34076,7 @@ name = r;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 229, 40}";
+transform = "{1, 0, 0, 1, -21, 25}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -33992,21 +34090,21 @@ unicode = 0213;
 {
 color = 3;
 glyphname = s;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-02-28 20:07:14 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{50, 0}";
+position = "{60, 40}";
 },
 {
 name = cedilla;
-position = "{122, 0}";
+position = "{92, 20}";
 },
 {
 name = top;
-position = "{221, 244}";
+position = "{221, 241}";
 }
 );
 background = {
@@ -34192,7 +34290,7 @@ unicode = 0073;
 },
 {
 glyphname = sacute;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -34211,7 +34309,7 @@ name = s;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 221, 0}";
+transform = "{1, 0, 0, 1, -29, -3}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34224,7 +34322,7 @@ unicode = 015B;
 },
 {
 glyphname = scaron;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -34243,7 +34341,7 @@ name = s;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 221, 0}";
+transform = "{1, 0, 0, 1, -29, -3}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34256,7 +34354,7 @@ unicode = 0161;
 },
 {
 glyphname = scedilla;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -34275,7 +34373,7 @@ name = s;
 },
 {
 name = cedillacomb;
-transform = "{1, 0, 0, 1, 122, 0}";
+transform = "{1, 0, 0, 1, -158, 20}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34288,7 +34386,7 @@ unicode = 015F;
 },
 {
 glyphname = scircumflex;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -34307,7 +34405,7 @@ name = s;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 221, 0}";
+transform = "{1, 0, 0, 1, -29, -3}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34320,7 +34418,7 @@ unicode = 015D;
 },
 {
 glyphname = scommaaccent;
-lastChange = "2022-02-14 13:08:02 +0000";
+lastChange = "2022-03-01 14:27:49 +0000";
 layers = (
 {
 background = {
@@ -34339,7 +34437,7 @@ name = s;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 50, 0}";
+transform = "{1, 0, 0, 1, -190, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34654,13 +34752,13 @@ unicode = 00DF;
 {
 color = 3;
 glyphname = t;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 20:14:50 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{100, 0}";
+position = "{110, 40}";
 },
 {
 name = cedilla;
@@ -34848,7 +34946,7 @@ unicode = 0074;
 },
 {
 glyphname = tbar;
-lastChange = "2022-02-14 13:08:14 +0000";
+lastChange = "2022-03-01 13:09:15 +0000";
 layers = (
 {
 background = {
@@ -34867,7 +34965,7 @@ name = t;
 },
 {
 name = strokeshortcomb;
-transform = "{1, 0, 0, 1, 64, 247}";
+transform = "{1, 0, 0, 1, -186, -53}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34880,7 +34978,7 @@ unicode = 0167;
 },
 {
 glyphname = tcaron;
-lastChange = "2022-02-14 13:08:14 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -34899,7 +34997,7 @@ name = t;
 },
 {
 name = caroncomb.alt;
-transform = "{1, 0, 0, 1, 220, -110}";
+transform = "{1, 0, 0, 1, -30, -110}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34912,7 +35010,7 @@ unicode = 0165;
 },
 {
 glyphname = tcedilla;
-lastChange = "2022-02-14 13:08:14 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -34931,7 +35029,7 @@ name = t;
 },
 {
 name = cedillacomb;
-transform = "{1, 0, 0, 1, 136, 0}";
+transform = "{1, 0, 0, 1, -114, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34944,7 +35042,7 @@ unicode = 0163;
 },
 {
 glyphname = tcommaaccent;
-lastChange = "2022-02-14 13:08:14 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -34963,7 +35061,7 @@ name = t;
 },
 {
 name = commaaccentcomb;
-transform = "{1, 0, 0, 1, 100, 0}";
+transform = "{1, 0, 0, 1, -140, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -34977,13 +35075,13 @@ unicode = 021B;
 {
 color = 3;
 glyphname = u;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-02-28 20:15:26 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{64, 0}";
+position = "{70, 40}";
 },
 {
 name = horn;
@@ -34995,7 +35093,7 @@ position = "{240, 0}";
 },
 {
 name = top;
-position = "{199, 200}";
+position = "{179, 160}";
 }
 );
 background = {
@@ -35159,7 +35257,7 @@ unicode = 0075;
 },
 {
 glyphname = uacute;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35178,7 +35276,7 @@ name = u;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35191,7 +35289,7 @@ unicode = 00FA;
 },
 {
 glyphname = ubreve;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35210,7 +35308,7 @@ name = u;
 },
 {
 name = brevecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35224,7 +35322,7 @@ unicode = 016D;
 {
 color = 9;
 glyphname = ucaron;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 components = (
@@ -35233,7 +35331,7 @@ name = u;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35246,7 +35344,7 @@ unicode = 01D4;
 },
 {
 glyphname = ucircumflex;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35265,7 +35363,7 @@ name = u;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35278,7 +35376,7 @@ unicode = 00FB;
 },
 {
 glyphname = udblgrave;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35297,7 +35395,7 @@ name = u;
 },
 {
 name = dblgravecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35310,7 +35408,7 @@ unicode = 0215;
 },
 {
 glyphname = udieresis;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35329,7 +35427,7 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35341,9 +35439,9 @@ rightKerningGroup = u;
 unicode = 00FC;
 },
 {
-color = 9;
+color = 3;
 glyphname = udieresiscaron;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:29:18 +0000";
 layers = (
 {
 components = (
@@ -35352,11 +35450,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 },
 {
+alignment = -1;
 name = caroncomb;
-transform = "{1, 0, 0, 1, 199, 96}";
+transform = "{1, 0, 0, 1, -51, 16}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35368,9 +35467,9 @@ rightKerningGroup = u;
 unicode = 01DA;
 },
 {
-color = 9;
+color = 3;
 glyphname = udieresisgrave;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:29:18 +0000";
 layers = (
 {
 components = (
@@ -35379,11 +35478,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 },
 {
+alignment = -1;
 name = gravecomb;
-transform = "{1, 0, 0, 1, 199, 96}";
+transform = "{1, 0, 0, 1, -61, 16}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35395,9 +35495,9 @@ rightKerningGroup = u;
 unicode = 01DC;
 },
 {
-color = 9;
+color = 3;
 glyphname = udieresismacron;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:29:18 +0000";
 layers = (
 {
 components = (
@@ -35406,11 +35506,12 @@ name = u;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 },
 {
+alignment = -1;
 name = macroncomb;
-transform = "{1, 0, 0, 1, 199, 96}";
+transform = "{1, 0, 0, 1, -51, 6}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35423,7 +35524,7 @@ unicode = 01D6;
 },
 {
 glyphname = udotbelow;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35442,7 +35543,7 @@ name = u;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 64, 0}";
+transform = "{1, 0, 0, 1, -180, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35455,7 +35556,7 @@ unicode = 1EE5;
 },
 {
 glyphname = ugrave;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35474,7 +35575,7 @@ name = u;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35487,7 +35588,7 @@ unicode = 00F9;
 },
 {
 glyphname = uhookabove;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35506,7 +35607,7 @@ name = u;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35519,7 +35620,7 @@ unicode = 1EE7;
 },
 {
 glyphname = uhorn;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35539,7 +35640,7 @@ name = u;
 },
 {
 name = horncomb;
-transform = "{1, 0, 0, 1, 247, -51}";
+transform = "{1, 0, 0, 1, -3, -51}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35552,7 +35653,7 @@ unicode = 01B0;
 },
 {
 glyphname = uhornacute;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35571,7 +35672,7 @@ name = uhorn;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35584,7 +35685,7 @@ unicode = 1EE9;
 },
 {
 glyphname = uhorndotbelow;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35603,7 +35704,7 @@ name = uhorn;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 64, 0}";
+transform = "{1, 0, 0, 1, -180, 40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35616,7 +35717,7 @@ unicode = 1EF1;
 },
 {
 glyphname = uhorngrave;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35635,7 +35736,7 @@ name = uhorn;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35648,7 +35749,7 @@ unicode = 1EEB;
 },
 {
 glyphname = uhornhookabove;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35667,7 +35768,7 @@ name = uhorn;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35680,7 +35781,7 @@ unicode = 1EED;
 },
 {
 glyphname = uhorntilde;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35699,7 +35800,7 @@ name = uhorn;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35712,7 +35813,7 @@ unicode = 1EEF;
 },
 {
 glyphname = uhungarumlaut;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35731,7 +35832,7 @@ name = u;
 },
 {
 name = hungarumlautcomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35744,7 +35845,7 @@ unicode = 0171;
 },
 {
 glyphname = uinvertedbreve;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35763,7 +35864,7 @@ name = u;
 },
 {
 name = breveinvertedcomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35776,7 +35877,7 @@ unicode = 0217;
 },
 {
 glyphname = umacron;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35795,7 +35896,7 @@ name = u;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35808,7 +35909,7 @@ unicode = 016B;
 },
 {
 glyphname = uogonek;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35827,7 +35928,7 @@ name = u;
 },
 {
 name = ogonekcomb;
-transform = "{1, 0, 0, 1, 240, 0}";
+transform = "{1, 0, 0, 1, -10, 0}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35840,7 +35941,7 @@ unicode = 0173;
 },
 {
 glyphname = uring;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35859,7 +35960,7 @@ name = u;
 },
 {
 name = ringcomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -35872,7 +35973,7 @@ unicode = 016F;
 },
 {
 glyphname = utilde;
-lastChange = "2022-02-14 13:08:24 +0000";
+lastChange = "2022-03-01 14:27:59 +0000";
 layers = (
 {
 background = {
@@ -35891,7 +35992,7 @@ name = u;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 199, -44}";
+transform = "{1, 0, 0, 1, -71, -84}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36103,7 +36204,7 @@ unicode = 0076;
 {
 color = 3;
 glyphname = w;
-lastChange = "2022-02-14 13:08:36 +0000";
+lastChange = "2022-02-28 20:16:36 +0000";
 layers = (
 {
 anchors = (
@@ -36113,7 +36214,7 @@ position = "{187, 0}";
 },
 {
 name = top;
-position = "{267, 214}";
+position = "{247, 174}";
 }
 );
 background = {
@@ -36323,7 +36424,7 @@ unicode = 0077;
 },
 {
 glyphname = wacute;
-lastChange = "2022-02-14 13:08:36 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36342,7 +36443,7 @@ name = w;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 267, -30}";
+transform = "{1, 0, 0, 1, -3, -70}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36355,7 +36456,7 @@ unicode = 1E83;
 },
 {
 glyphname = wcircumflex;
-lastChange = "2022-02-14 13:08:36 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36374,7 +36475,7 @@ name = w;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 267, -30}";
+transform = "{1, 0, 0, 1, -3, -70}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36387,7 +36488,7 @@ unicode = 0175;
 },
 {
 glyphname = wdieresis;
-lastChange = "2022-02-14 13:08:36 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36406,7 +36507,7 @@ name = w;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 267, -30}";
+transform = "{1, 0, 0, 1, -3, -70}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36419,7 +36520,7 @@ unicode = 1E85;
 },
 {
 glyphname = wgrave;
-lastChange = "2022-02-14 13:08:36 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36438,7 +36539,7 @@ name = w;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 267, -30}";
+transform = "{1, 0, 0, 1, -3, -70}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36638,7 +36739,7 @@ unicode = 0078;
 {
 color = 3;
 glyphname = y;
-lastChange = "2022-02-14 17:33:07 +0000";
+lastChange = "2022-02-28 20:19:01 +0000";
 layers = (
 {
 anchors = (
@@ -36648,7 +36749,7 @@ position = "{200, -219}";
 },
 {
 name = top;
-position = "{196, 244}";
+position = "{196, 204}";
 }
 );
 background = {
@@ -36868,7 +36969,7 @@ unicode = 0079;
 },
 {
 glyphname = yacute;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36887,7 +36988,7 @@ name = y;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36900,7 +37001,7 @@ unicode = 00FD;
 },
 {
 glyphname = ycircumflex;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36919,7 +37020,7 @@ name = y;
 },
 {
 name = circumflexcomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36932,7 +37033,7 @@ unicode = 0177;
 },
 {
 glyphname = ydieresis;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36951,7 +37052,7 @@ name = y;
 },
 {
 name = dieresiscomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36964,7 +37065,7 @@ unicode = 00FF;
 },
 {
 glyphname = ydotbelow;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -36983,7 +37084,7 @@ name = y;
 },
 {
 name = dotbelowcomb;
-transform = "{1, 0, 0, 1, 200, -219}";
+transform = "{1, 0, 0, 1, -50, -219}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -36996,7 +37097,7 @@ unicode = 1EF5;
 },
 {
 glyphname = ygrave;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37015,7 +37116,7 @@ name = y;
 },
 {
 name = gravecomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37028,7 +37129,7 @@ unicode = 1EF3;
 },
 {
 glyphname = yhookabove;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37047,7 +37148,7 @@ name = y;
 },
 {
 name = hookabovecomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37060,7 +37161,7 @@ unicode = 1EF7;
 },
 {
 glyphname = ymacron;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37079,7 +37180,7 @@ name = y;
 },
 {
 name = macroncomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37092,7 +37193,7 @@ unicode = 0233;
 },
 {
 glyphname = ytilde;
-lastChange = "2022-02-14 13:08:56 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37111,7 +37212,7 @@ name = y;
 },
 {
 name = tildecomb;
-transform = "{1, 0, 0, 1, 196, 0}";
+transform = "{1, 0, 0, 1, -54, -40}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37125,7 +37226,7 @@ unicode = 1EF9;
 {
 color = 3;
 glyphname = z;
-lastChange = "2022-02-14 13:09:02 +0000";
+lastChange = "2022-02-28 20:26:34 +0000";
 layers = (
 {
 anchors = (
@@ -37135,7 +37236,7 @@ position = "{25, -396}";
 },
 {
 name = top;
-position = "{217, 244}";
+position = "{214, 199}";
 }
 );
 background = {
@@ -37342,7 +37443,7 @@ unicode = 007A;
 },
 {
 glyphname = zacute;
-lastChange = "2022-02-14 13:09:02 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37361,7 +37462,7 @@ name = z;
 },
 {
 name = acutecomb;
-transform = "{1, 0, 0, 1, 217, 0}";
+transform = "{1, 0, 0, 1, -36, -45}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37374,7 +37475,7 @@ unicode = 017A;
 },
 {
 glyphname = zcaron;
-lastChange = "2022-02-14 13:09:02 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37393,7 +37494,7 @@ name = z;
 },
 {
 name = caroncomb;
-transform = "{1, 0, 0, 1, 217, 0}";
+transform = "{1, 0, 0, 1, -36, -45}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -37406,7 +37507,7 @@ unicode = 017E;
 },
 {
 glyphname = zdotaccent;
-lastChange = "2022-02-14 13:09:02 +0000";
+lastChange = "2022-03-01 14:28:08 +0000";
 layers = (
 {
 background = {
@@ -37425,7 +37526,7 @@ name = z;
 },
 {
 name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 217, 0}";
+transform = "{1, 0, 0, 1, -36, -45}";
 }
 );
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
@@ -38361,7 +38462,7 @@ rightKerningGroup = i;
 {
 color = 3;
 glyphname = f_f_l;
-lastChange = "2022-02-14 21:32:36 +0000";
+lastChange = "2022-03-01 15:02:38 +0000";
 layers = (
 {
 anchors = (
@@ -38697,7 +38798,7 @@ nodes = (
 "-3 -58 OFFCURVE",
 "36 57 CURVE SMOOTH",
 "47 89 OFFCURVE",
-"57 112 OFFCURVE",
+"56 112 OFFCURVE",
 "61 128 CURVE SMOOTH",
 "66 143 LINE",
 "68 104 OFFCURVE",
@@ -38812,63 +38913,63 @@ nodes = (
 {
 closed = 1;
 nodes = (
-"681 10 OFFCURVE",
-"729 37 OFFCURVE",
-"785 110 CURVE SMOOTH",
-"791 118 OFFCURVE",
-"793 125 OFFCURVE",
-"793 129 CURVE SMOOTH",
-"793 132 OFFCURVE",
-"792 134 OFFCURVE",
-"790 134 CURVE SMOOTH",
-"788 134 OFFCURVE",
-"785 132 OFFCURVE",
-"782 128 CURVE SMOOTH",
-"737 71 OFFCURVE",
-"702 36 OFFCURVE",
-"645 36 CURVE SMOOTH",
-"597 36 OFFCURVE",
-"570 66 OFFCURVE",
-"562 127 CURVE",
-"610 177 OFFCURVE",
-"664 250 OFFCURVE",
-"728 348 CURVE SMOOTH",
-"802 462 OFFCURVE",
-"839 543 OFFCURVE",
-"839 591 CURVE SMOOTH",
-"839 605 LINE",
-"832 632 OFFCURVE",
-"820 646 OFFCURVE",
-"799 646 CURVE SMOOTH",
-"743 646 OFFCURVE",
-"684 589 OFFCURVE",
-"621 475 CURVE SMOOTH",
-"557 361 OFFCURVE",
-"525 256 OFFCURVE",
-"525 158 CURVE SMOOTH",
-"525 60 OFFCURVE",
-"558 10 OFFCURVE",
-"625 10 CURVE SMOOTH"
+"681 -12 OFFCURVE",
+"729 16 OFFCURVE",
+"786 89 CURVE",
+"791 97 OFFCURVE",
+"793 103 OFFCURVE",
+"793 107 CURVE SMOOTH",
+"793 110 OFFCURVE",
+"792 112 OFFCURVE",
+"790 112 CURVE SMOOTH",
+"789 112 OFFCURVE",
+"786 110 OFFCURVE",
+"782 106 CURVE SMOOTH",
+"737 50 OFFCURVE",
+"702 15 OFFCURVE",
+"645 15 CURVE SMOOTH",
+"597 15 OFFCURVE",
+"570 45 OFFCURVE",
+"562 105 CURVE",
+"610 155 OFFCURVE",
+"665 228 OFFCURVE",
+"728 327 CURVE SMOOTH",
+"802 441 OFFCURVE",
+"839 522 OFFCURVE",
+"839 570 CURVE SMOOTH",
+"839 583 LINE",
+"832 611 OFFCURVE",
+"820 624 OFFCURVE",
+"799 624 CURVE SMOOTH",
+"744 624 OFFCURVE",
+"684 568 OFFCURVE",
+"621 454 CURVE SMOOTH",
+"557 340 OFFCURVE",
+"525 234 OFFCURVE",
+"525 137 CURVE SMOOTH",
+"525 38 OFFCURVE",
+"558 -12 OFFCURVE",
+"626 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"563 228 OFFCURVE",
-"588 325 OFFCURVE",
-"639 441 CURVE SMOOTH",
-"692 560 OFFCURVE",
-"739 620 OFFCURVE",
-"780 620 CURVE SMOOTH",
-"790 620 OFFCURVE",
-"796 610 OFFCURVE",
-"796 591 CURVE SMOOTH",
-"796 549 OFFCURVE",
-"765 472 OFFCURVE",
-"703 361 CURVE SMOOTH",
-"646 257 OFFCURVE",
-"599 186 OFFCURVE",
-"563 151 CURVE"
+"563 207 OFFCURVE",
+"589 303 OFFCURVE",
+"639 420 CURVE SMOOTH",
+"692 539 OFFCURVE",
+"739 598 OFFCURVE",
+"780 598 CURVE SMOOTH",
+"790 598 OFFCURVE",
+"796 588 OFFCURVE",
+"796 570 CURVE SMOOTH",
+"796 528 OFFCURVE",
+"765 451 OFFCURVE",
+"704 340 CURVE SMOOTH",
+"646 235 OFFCURVE",
+"599 165 OFFCURVE",
+"563 130 CURVE"
 );
 }
 );
@@ -38878,6 +38979,7 @@ width = 746;
 leftKerningGroup = f;
 leftMetricsKey = f;
 rightKerningGroup = l;
+rightMetricsKey = l;
 },
 {
 color = 3;
@@ -43576,218 +43678,6 @@ note = nine;
 rightKerningGroup = nine;
 },
 {
-color = 3;
-glyphname = fraction;
-lastChange = "2022-02-16 09:47:53 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"35 -17 OFFCURVE",
-"37 -16 OFFCURVE",
-"38 -14 CURVE SMOOTH",
-"45 6 OFFCURVE",
-"50 19 OFFCURVE",
-"53 23 CURVE",
-"86 93 OFFCURVE",
-"159 185 OFFCURVE",
-"272 300 CURVE SMOOTH",
-"324 351 LINE SMOOTH",
-"325 352 OFFCURVE",
-"326 353 OFFCURVE",
-"326 354 CURVE SMOOTH",
-"326 360 OFFCURVE",
-"321 363 OFFCURVE",
-"311 363 CURVE SMOOTH",
-"307 363 OFFCURVE",
-"304 362 OFFCURVE",
-"301 360 CURVE",
-"275 336 OFFCURVE",
-"256 316 OFFCURVE",
-"243 302 CURVE SMOOTH",
-"144 196 OFFCURVE",
-"77 102 OFFCURVE",
-"39 21 CURVE SMOOTH",
-"30 3 OFFCURVE",
-"26 -9 OFFCURVE",
-"26 -12 CURVE SMOOTH",
-"26 -15 OFFCURVE",
-"28 -17 OFFCURVE",
-"32 -17 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"81 25 OFFCURVE",
-"101 66 OFFCURVE",
-"132 115 CURVE SMOOTH",
-"201 228 OFFCURVE",
-"481 507 OFFCURVE",
-"582 588 CURVE SMOOTH",
-"584 590 OFFCURVE",
-"585 592 OFFCURVE",
-"585 593 CURVE SMOOTH",
-"585 595 OFFCURVE",
-"582 596 OFFCURVE",
-"577 596 CURVE SMOOTH",
-"564 596 OFFCURVE",
-"551 591 OFFCURVE",
-"539 582 CURVE SMOOTH",
-"501 550 OFFCURVE",
-"349 408 OFFCURVE",
-"291 348 CURVE SMOOTH",
-"247 303 OFFCURVE",
-"124 151 OFFCURVE",
-"84 82 CURVE SMOOTH",
-"74 63 OFFCURVE",
-"61 39 OFFCURVE",
-"61 24 CURVE SMOOTH",
-"61 15 OFFCURVE",
-"70 10 OFFCURVE",
-"75 10 CURVE"
-);
-}
-);
-width = 554;
-}
-);
-note = fraction;
-unicode = 2044;
-},
-{
-glyphname = onehalf;
-lastChange = "2022-02-10 19:38:10 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = onesuperior;
-},
-{
-name = divisionslash;
-},
-{
-name = twosuperior;
-transform = "{1, 0, 0, 1, 275, -362}";
-}
-);
-};
-components = (
-{
-alignment = -1;
-name = onesuperior;
-},
-{
-alignment = -1;
-name = divisionslash;
-},
-{
-alignment = -1;
-name = twosuperior;
-transform = "{1, 0, 0, 1, 269, -353}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 662;
-}
-);
-note = onehalf;
-unicode = 00BD;
-},
-{
-glyphname = onequarter;
-lastChange = "2022-02-10 19:38:10 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = onesuperior;
-},
-{
-name = divisionslash;
-},
-{
-name = foursuperior;
-transform = "{1, 0, 0, 1, 274, -343}";
-}
-);
-};
-components = (
-{
-alignment = -1;
-name = onesuperior;
-},
-{
-alignment = -1;
-name = divisionslash;
-},
-{
-alignment = -1;
-name = foursuperior;
-transform = "{1, 0, 0, 1, 268, -335}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 691;
-}
-);
-note = onequarter;
-unicode = 00BC;
-},
-{
-glyphname = threequarters;
-lastChange = "2022-02-10 19:38:10 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = threesuperior;
-},
-{
-name = divisionslash;
-transform = "{1, 0, 0, 1, 97, 0}";
-},
-{
-name = foursuperior;
-transform = "{1, 0, 0, 1, 371, -343}";
-}
-);
-};
-components = (
-{
-alignment = -1;
-name = threesuperior;
-},
-{
-alignment = -1;
-name = divisionslash;
-transform = "{1, 0, 0, 1, 95, 0}";
-},
-{
-alignment = -1;
-name = foursuperior;
-transform = "{1, 0, 0, 1, 362, -335}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 785;
-}
-);
-note = threequarters;
-unicode = 00BE;
-},
-{
 glyphname = onesuperior;
 lastChange = "2022-02-07 18:28:46 +0000";
 layers = (
@@ -44647,8 +44537,9 @@ width = 419;
 unicode = 2074;
 },
 {
-glyphname = "leftanglebracket-math";
-lastChange = "2022-02-14 09:32:40 +0000";
+color = 3;
+glyphname = fraction;
+lastChange = "2022-02-16 09:47:53 +0000";
 layers = (
 {
 background = {
@@ -44656,31 +44547,37 @@ paths = (
 {
 closed = 1;
 nodes = (
-"295 -80 OFFCURVE",
-"298 -75 OFFCURVE",
-"299 -66 CURVE SMOOTH",
-"300 -60 OFFCURVE",
-"234 90 OFFCURVE",
-"174 244 CURVE",
-"243 357 OFFCURVE",
-"412 606 OFFCURVE",
-"422 622 CURVE SMOOTH",
-"434 639 OFFCURVE",
-"420 641 OFFCURVE",
-"415 641 CURVE SMOOTH",
-"409 641 OFFCURVE",
-"401 637 OFFCURVE",
-"394 630 CURVE SMOOTH",
-"358 592 OFFCURVE",
-"184 326 OFFCURVE",
-"154 277 CURVE SMOOTH",
-"139 253 OFFCURVE",
-"121 231 OFFCURVE",
-"130 212 CURVE",
-"202 68 OFFCURVE",
-"268 -54 OFFCURVE",
-"281 -75 CURVE",
-"289 -79 LINE"
+"35 -17 OFFCURVE",
+"37 -16 OFFCURVE",
+"38 -14 CURVE SMOOTH",
+"45 6 OFFCURVE",
+"50 19 OFFCURVE",
+"53 23 CURVE",
+"86 93 OFFCURVE",
+"159 185 OFFCURVE",
+"272 300 CURVE SMOOTH",
+"324 351 LINE SMOOTH",
+"325 352 OFFCURVE",
+"326 353 OFFCURVE",
+"326 354 CURVE SMOOTH",
+"326 360 OFFCURVE",
+"321 363 OFFCURVE",
+"311 363 CURVE SMOOTH",
+"307 363 OFFCURVE",
+"304 362 OFFCURVE",
+"301 360 CURVE",
+"275 336 OFFCURVE",
+"256 316 OFFCURVE",
+"243 302 CURVE SMOOTH",
+"144 196 OFFCURVE",
+"77 102 OFFCURVE",
+"39 21 CURVE SMOOTH",
+"30 3 OFFCURVE",
+"26 -9 OFFCURVE",
+"26 -12 CURVE SMOOTH",
+"26 -15 OFFCURVE",
+"28 -17 OFFCURVE",
+"32 -17 CURVE SMOOTH"
 );
 }
 );
@@ -44690,127 +44587,166 @@ paths = (
 {
 closed = 1;
 nodes = (
-"295 -80 OFFCURVE",
-"298 -75 OFFCURVE",
-"299 -66 CURVE SMOOTH",
-"300 -60 OFFCURVE",
-"234 90 OFFCURVE",
-"174 244 CURVE",
-"243 357 OFFCURVE",
-"412 606 OFFCURVE",
-"422 622 CURVE SMOOTH",
-"425 626 OFFCURVE",
-"427 630 OFFCURVE",
-"427 633 CURVE SMOOTH",
-"427 640 OFFCURVE",
-"419 641 OFFCURVE",
-"415 641 CURVE SMOOTH",
-"409 641 OFFCURVE",
-"401 637 OFFCURVE",
-"394 630 CURVE SMOOTH",
-"358 592 OFFCURVE",
-"184 326 OFFCURVE",
-"154 277 CURVE SMOOTH",
-"142 257 OFFCURVE",
-"128 239 OFFCURVE",
-"128 222 CURVE SMOOTH",
-"128 219 OFFCURVE",
-"128 216 OFFCURVE",
-"130 212 CURVE SMOOTH",
-"202 68 OFFCURVE",
-"268 -54 OFFCURVE",
-"281 -75 CURVE",
-"289 -79 LINE"
+"81 25 OFFCURVE",
+"101 66 OFFCURVE",
+"132 115 CURVE SMOOTH",
+"201 228 OFFCURVE",
+"481 507 OFFCURVE",
+"582 588 CURVE SMOOTH",
+"584 590 OFFCURVE",
+"585 592 OFFCURVE",
+"585 593 CURVE SMOOTH",
+"585 595 OFFCURVE",
+"582 596 OFFCURVE",
+"577 596 CURVE SMOOTH",
+"564 596 OFFCURVE",
+"551 591 OFFCURVE",
+"539 582 CURVE SMOOTH",
+"501 550 OFFCURVE",
+"349 408 OFFCURVE",
+"291 348 CURVE SMOOTH",
+"247 303 OFFCURVE",
+"124 151 OFFCURVE",
+"84 82 CURVE SMOOTH",
+"74 63 OFFCURVE",
+"61 39 OFFCURVE",
+"61 24 CURVE SMOOTH",
+"61 15 OFFCURVE",
+"70 10 OFFCURVE",
+"75 10 CURVE"
 );
 }
 );
-width = 495;
+width = 554;
 }
 );
-unicode = 27E8;
+note = fraction;
+unicode = 2044;
 },
 {
-glyphname = "rightanglebracket-math";
-lastChange = "2022-02-07 18:28:46 +0000";
+glyphname = onehalf;
+lastChange = "2022-02-10 19:38:10 +0000";
 layers = (
 {
 background = {
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"229 642 OFFCURVE",
-"226 637 OFFCURVE",
-"225 628 CURVE SMOOTH",
-"224 622 OFFCURVE",
-"291 472 OFFCURVE",
-"350 318 CURVE",
-"282 205 OFFCURVE",
-"113 -44 OFFCURVE",
-"102 -60 CURVE SMOOTH",
-"91 -77 OFFCURVE",
-"104 -79 OFFCURVE",
-"109 -79 CURVE SMOOTH",
-"116 -79 OFFCURVE",
-"124 -75 OFFCURVE",
-"131 -68 CURVE SMOOTH",
-"167 -30 OFFCURVE",
-"341 236 OFFCURVE",
-"371 285 CURVE SMOOTH",
-"385 309 OFFCURVE",
-"404 331 OFFCURVE",
-"395 350 CURVE",
-"323 494 OFFCURVE",
-"257 616 OFFCURVE",
-"244 637 CURVE",
-"236 641 LINE"
-);
+name = onesuperior;
+},
+{
+name = divisionslash;
+},
+{
+name = twosuperior;
+transform = "{1, 0, 0, 1, 275, -362}";
 }
 );
 };
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
+components = (
 {
-closed = 1;
-nodes = (
-"116 -79 OFFCURVE",
-"124 -75 OFFCURVE",
-"131 -68 CURVE SMOOTH",
-"167 -30 OFFCURVE",
-"341 236 OFFCURVE",
-"371 285 CURVE SMOOTH",
-"382 305 OFFCURVE",
-"397 323 OFFCURVE",
-"397 340 CURVE SMOOTH",
-"397 343 OFFCURVE",
-"397 346 OFFCURVE",
-"395 350 CURVE SMOOTH",
-"323 494 OFFCURVE",
-"257 616 OFFCURVE",
-"244 637 CURVE",
-"236 641 LINE",
-"229 642 OFFCURVE",
-"226 637 OFFCURVE",
-"225 628 CURVE SMOOTH",
-"224 622 OFFCURVE",
-"291 472 OFFCURVE",
-"350 318 CURVE",
-"282 205 OFFCURVE",
-"113 -44 OFFCURVE",
-"102 -60 CURVE SMOOTH",
-"100 -64 OFFCURVE",
-"98 -68 OFFCURVE",
-"98 -71 CURVE SMOOTH",
-"98 -78 OFFCURVE",
-"105 -79 OFFCURVE",
-"109 -79 CURVE SMOOTH"
-);
+alignment = -1;
+name = onesuperior;
+},
+{
+alignment = -1;
+name = divisionslash;
+},
+{
+alignment = -1;
+name = twosuperior;
+transform = "{1, 0, 0, 1, 269, -353}";
 }
 );
-width = 495;
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 662;
 }
 );
-unicode = 27E9;
+note = onehalf;
+unicode = 00BD;
+},
+{
+glyphname = onequarter;
+lastChange = "2022-02-10 19:38:10 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = onesuperior;
+},
+{
+name = divisionslash;
+},
+{
+name = foursuperior;
+transform = "{1, 0, 0, 1, 274, -343}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = onesuperior;
+},
+{
+alignment = -1;
+name = divisionslash;
+},
+{
+alignment = -1;
+name = foursuperior;
+transform = "{1, 0, 0, 1, 268, -335}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 691;
+}
+);
+note = onequarter;
+unicode = 00BC;
+},
+{
+glyphname = threequarters;
+lastChange = "2022-02-10 19:38:10 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = threesuperior;
+},
+{
+name = divisionslash;
+transform = "{1, 0, 0, 1, 97, 0}";
+},
+{
+name = foursuperior;
+transform = "{1, 0, 0, 1, 371, -343}";
+}
+);
+};
+components = (
+{
+alignment = -1;
+name = threesuperior;
+},
+{
+alignment = -1;
+name = divisionslash;
+transform = "{1, 0, 0, 1, 95, 0}";
+},
+{
+alignment = -1;
+name = foursuperior;
+transform = "{1, 0, 0, 1, 362, -335}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 785;
+}
+);
+note = threequarters;
+unicode = 00BE;
 },
 {
 glyphname = period;
@@ -47014,54 +46950,6 @@ unicode = 005C;
 },
 {
 color = 3;
-glyphname = periodcentered.loclCAT;
-lastChange = "2022-02-14 14:49:20 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = period;
-transform = "{1, 0, 0, 1, -104, 172}";
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-30 153 OFFCURVE",
-"-20 164 OFFCURVE",
-"-13 186 CURVE SMOOTH",
-"-5 214 OFFCURVE",
-"6 226 OFFCURVE",
-"15 236 CURVE",
-"14 237 LINE SMOOTH",
-"13 238 OFFCURVE",
-"13 238 OFFCURVE",
-"12 238 CURVE SMOOTH",
-"7 238 OFFCURVE",
-"-4 234 OFFCURVE",
-"-18 227 CURVE SMOOTH",
-"-33 219 OFFCURVE",
-"-42 213 OFFCURVE",
-"-45 208 CURVE",
-"-57 203 OFFCURVE",
-"-63 195 OFFCURVE",
-"-63 184 CURVE SMOOTH",
-"-63 173 OFFCURVE",
-"-53 153 OFFCURVE",
-"-43 153 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-},
-{
-color = 3;
 glyphname = periodcentered.loclCAT.case;
 lastChange = "2022-02-14 21:30:41 +0000";
 layers = (
@@ -47109,141 +46997,16 @@ width = 0;
 );
 },
 {
-glyphname = hyphen;
-lastChange = "2022-02-14 20:35:03 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"92 163 OFFCURVE",
-"109 165 OFFCURVE",
-"153 168 CURVE SMOOTH",
-"199 172 OFFCURVE",
-"240 174 OFFCURVE",
-"275 174 CURVE SMOOTH",
-"279 174 OFFCURVE",
-"281 176 OFFCURVE",
-"281 179 CURVE SMOOTH",
-"281 181 OFFCURVE",
-"280 181 OFFCURVE",
-"278 182 CURVE SMOOTH",
-"256 189 OFFCURVE",
-"221 193 OFFCURVE",
-"175 193 CURVE SMOOTH",
-"144 193 OFFCURVE",
-"113 191 OFFCURVE",
-"80 187 CURVE",
-"78 185 LINE",
-"79 179 OFFCURVE",
-"92 163 OFFCURVE",
-"99 163 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"92 163 OFFCURVE",
-"109 165 OFFCURVE",
-"153 168 CURVE SMOOTH",
-"199 172 OFFCURVE",
-"240 174 OFFCURVE",
-"275 174 CURVE SMOOTH",
-"279 174 OFFCURVE",
-"281 176 OFFCURVE",
-"281 179 CURVE SMOOTH",
-"281 181 OFFCURVE",
-"280 181 OFFCURVE",
-"278 182 CURVE SMOOTH",
-"256 189 OFFCURVE",
-"221 193 OFFCURVE",
-"175 193 CURVE SMOOTH",
-"144 193 OFFCURVE",
-"113 191 OFFCURVE",
-"80 187 CURVE",
-"78 185 LINE",
-"79 179 OFFCURVE",
-"92 163 OFFCURVE",
-"99 163 CURVE"
-);
-}
-);
-width = 311;
-}
-);
-leftKerningGroup = hyphen;
-note = hyphen;
-rightKerningGroup = hyphen;
-unicode = 002D;
-},
-{
-glyphname = softhyphen;
-lastChange = "2022-02-14 13:12:49 +0000";
+color = 3;
+glyphname = periodcentered.loclCAT;
+lastChange = "2022-02-14 14:49:20 +0000";
 layers = (
 {
 background = {
 components = (
 {
-name = hyphen;
-}
-);
-};
-components = (
-{
-name = hyphen;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 311;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 00AD;
-},
-{
-glyphname = endash;
-lastChange = "2022-02-14 13:12:49 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"101 117 OFFCURVE",
-"124 118 OFFCURVE",
-"169 121 CURVE SMOOTH",
-"227 124 OFFCURVE",
-"277 126 OFFCURVE",
-"319 126 CURVE SMOOTH",
-"323 126 OFFCURVE",
-"326 127 OFFCURVE",
-"326 129 CURVE SMOOTH",
-"326 130 OFFCURVE",
-"325 131 OFFCURVE",
-"322 132 CURVE SMOOTH",
-"296 137 OFFCURVE",
-"254 140 OFFCURVE",
-"197 140 CURVE SMOOTH",
-"145 140 OFFCURVE",
-"106 138 OFFCURVE",
-"79 135 CURVE SMOOTH",
-"78 135 OFFCURVE",
-"78 135 OFFCURVE",
-"78 134 CURVE SMOOTH",
-"79 128 OFFCURVE",
-"101 114 OFFCURVE",
-"101 117 CURVE SMOOTH"
-);
+name = period;
+transform = "{1, 0, 0, 1, -104, 172}";
 }
 );
 };
@@ -47252,191 +47015,34 @@ paths = (
 {
 closed = 1;
 nodes = (
-"101 117 OFFCURVE",
-"124 118 OFFCURVE",
-"169 121 CURVE SMOOTH",
-"227 124 OFFCURVE",
-"277 126 OFFCURVE",
-"319 126 CURVE SMOOTH",
-"323 126 OFFCURVE",
-"326 127 OFFCURVE",
-"326 129 CURVE SMOOTH",
-"326 130 OFFCURVE",
-"325 131 OFFCURVE",
-"322 132 CURVE SMOOTH",
-"296 137 OFFCURVE",
-"254 140 OFFCURVE",
-"197 140 CURVE SMOOTH",
-"145 140 OFFCURVE",
-"106 138 OFFCURVE",
-"79 135 CURVE SMOOTH",
-"78 135 OFFCURVE",
-"78 135 OFFCURVE",
-"78 134 CURVE SMOOTH",
-"79 128 OFFCURVE",
-"101 114 OFFCURVE",
-"101 117 CURVE"
+"-30 153 OFFCURVE",
+"-20 164 OFFCURVE",
+"-13 186 CURVE SMOOTH",
+"-5 214 OFFCURVE",
+"6 226 OFFCURVE",
+"15 236 CURVE",
+"14 237 LINE SMOOTH",
+"13 238 OFFCURVE",
+"13 238 OFFCURVE",
+"12 238 CURVE SMOOTH",
+"7 238 OFFCURVE",
+"-4 234 OFFCURVE",
+"-18 227 CURVE SMOOTH",
+"-33 219 OFFCURVE",
+"-42 213 OFFCURVE",
+"-45 208 CURVE",
+"-57 203 OFFCURVE",
+"-63 195 OFFCURVE",
+"-63 184 CURVE SMOOTH",
+"-63 173 OFFCURVE",
+"-53 153 OFFCURVE",
+"-43 153 CURVE SMOOTH"
 );
 }
 );
-width = 356;
+width = 0;
 }
 );
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-note = endash;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2013;
-},
-{
-glyphname = emdash;
-lastChange = "2022-02-14 13:12:49 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"98 117 OFFCURVE",
-"112 118 OFFCURVE",
-"146 120 CURVE SMOOTH",
-"258 127 OFFCURVE",
-"395 130 OFFCURVE",
-"558 130 CURVE SMOOTH",
-"567 130 OFFCURVE",
-"571 131 OFFCURVE",
-"571 134 CURVE SMOOTH",
-"571 136 OFFCURVE",
-"569 137 OFFCURVE",
-"563 138 CURVE",
-"518 142 OFFCURVE",
-"482 144 OFFCURVE",
-"458 144 CURVE SMOOTH",
-"395 147 OFFCURVE",
-"331 149 OFFCURVE",
-"266 149 CURVE SMOOTH",
-"217 149 OFFCURVE",
-"174 147 OFFCURVE",
-"138 146 CURVE SMOOTH",
-"99 144 OFFCURVE",
-"79 142 OFFCURVE",
-"78 141 CURVE",
-"81 131 OFFCURVE",
-"98 117 OFFCURVE",
-"106 117 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"98 117 OFFCURVE",
-"112 118 OFFCURVE",
-"146 120 CURVE SMOOTH",
-"258 127 OFFCURVE",
-"395 130 OFFCURVE",
-"558 130 CURVE SMOOTH",
-"567 130 OFFCURVE",
-"571 131 OFFCURVE",
-"571 134 CURVE SMOOTH",
-"571 136 OFFCURVE",
-"569 137 OFFCURVE",
-"563 138 CURVE SMOOTH",
-"518 142 OFFCURVE",
-"482 144 OFFCURVE",
-"458 144 CURVE SMOOTH",
-"395 147 OFFCURVE",
-"331 149 OFFCURVE",
-"266 149 CURVE SMOOTH",
-"217 149 OFFCURVE",
-"174 147 OFFCURVE",
-"138 146 CURVE SMOOTH",
-"99 144 OFFCURVE",
-"79 142 OFFCURVE",
-"78 141 CURVE",
-"81 131 OFFCURVE",
-"98 117 OFFCURVE",
-"106 117 CURVE"
-);
-}
-);
-width = 601;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-note = emdash;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2014;
-},
-{
-glyphname = hyphentwo;
-lastChange = "2022-02-14 13:12:49 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = hyphen;
-}
-);
-};
-components = (
-{
-name = hyphen;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 311;
-}
-);
-leftKerningGroup = hyphen;
-leftMetricsKey = hyphen;
-rightKerningGroup = hyphen;
-rightMetricsKey = hyphen;
-unicode = 2010;
-},
-{
-glyphname = underscore;
-lastChange = "2022-02-14 09:46:18 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"560 -100 LINE",
-"560 -75 LINE",
-"-10 -75 LINE",
-"-10 -100 LINE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"560 -100 LINE",
-"560 -75 LINE",
-"-10 -75 LINE",
-"-10 -100 LINE"
-);
-}
-);
-width = 570;
-}
-);
-note = underscore;
-unicode = 005F;
 },
 {
 glyphname = parenleft;
@@ -48210,6 +47816,336 @@ width = 440;
 );
 note = bracketright;
 unicode = 005D;
+},
+{
+glyphname = hyphen;
+lastChange = "2022-02-14 20:35:03 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"92 163 OFFCURVE",
+"109 165 OFFCURVE",
+"153 168 CURVE SMOOTH",
+"199 172 OFFCURVE",
+"240 174 OFFCURVE",
+"275 174 CURVE SMOOTH",
+"279 174 OFFCURVE",
+"281 176 OFFCURVE",
+"281 179 CURVE SMOOTH",
+"281 181 OFFCURVE",
+"280 181 OFFCURVE",
+"278 182 CURVE SMOOTH",
+"256 189 OFFCURVE",
+"221 193 OFFCURVE",
+"175 193 CURVE SMOOTH",
+"144 193 OFFCURVE",
+"113 191 OFFCURVE",
+"80 187 CURVE",
+"78 185 LINE",
+"79 179 OFFCURVE",
+"92 163 OFFCURVE",
+"99 163 CURVE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 163 OFFCURVE",
+"109 165 OFFCURVE",
+"153 168 CURVE SMOOTH",
+"199 172 OFFCURVE",
+"240 174 OFFCURVE",
+"275 174 CURVE SMOOTH",
+"279 174 OFFCURVE",
+"281 176 OFFCURVE",
+"281 179 CURVE SMOOTH",
+"281 181 OFFCURVE",
+"280 181 OFFCURVE",
+"278 182 CURVE SMOOTH",
+"256 189 OFFCURVE",
+"221 193 OFFCURVE",
+"175 193 CURVE SMOOTH",
+"144 193 OFFCURVE",
+"113 191 OFFCURVE",
+"80 187 CURVE",
+"78 185 LINE",
+"79 179 OFFCURVE",
+"92 163 OFFCURVE",
+"99 163 CURVE"
+);
+}
+);
+width = 311;
+}
+);
+leftKerningGroup = hyphen;
+note = hyphen;
+rightKerningGroup = hyphen;
+unicode = 002D;
+},
+{
+glyphname = softhyphen;
+lastChange = "2022-02-14 13:12:49 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = hyphen;
+}
+);
+};
+components = (
+{
+name = hyphen;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 311;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 00AD;
+},
+{
+glyphname = endash;
+lastChange = "2022-02-14 13:12:49 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"101 117 OFFCURVE",
+"124 118 OFFCURVE",
+"169 121 CURVE SMOOTH",
+"227 124 OFFCURVE",
+"277 126 OFFCURVE",
+"319 126 CURVE SMOOTH",
+"323 126 OFFCURVE",
+"326 127 OFFCURVE",
+"326 129 CURVE SMOOTH",
+"326 130 OFFCURVE",
+"325 131 OFFCURVE",
+"322 132 CURVE SMOOTH",
+"296 137 OFFCURVE",
+"254 140 OFFCURVE",
+"197 140 CURVE SMOOTH",
+"145 140 OFFCURVE",
+"106 138 OFFCURVE",
+"79 135 CURVE SMOOTH",
+"78 135 OFFCURVE",
+"78 135 OFFCURVE",
+"78 134 CURVE SMOOTH",
+"79 128 OFFCURVE",
+"101 114 OFFCURVE",
+"101 117 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"101 117 OFFCURVE",
+"124 118 OFFCURVE",
+"169 121 CURVE SMOOTH",
+"227 124 OFFCURVE",
+"277 126 OFFCURVE",
+"319 126 CURVE SMOOTH",
+"323 126 OFFCURVE",
+"326 127 OFFCURVE",
+"326 129 CURVE SMOOTH",
+"326 130 OFFCURVE",
+"325 131 OFFCURVE",
+"322 132 CURVE SMOOTH",
+"296 137 OFFCURVE",
+"254 140 OFFCURVE",
+"197 140 CURVE SMOOTH",
+"145 140 OFFCURVE",
+"106 138 OFFCURVE",
+"79 135 CURVE SMOOTH",
+"78 135 OFFCURVE",
+"78 135 OFFCURVE",
+"78 134 CURVE SMOOTH",
+"79 128 OFFCURVE",
+"101 114 OFFCURVE",
+"101 117 CURVE"
+);
+}
+);
+width = 356;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+note = endash;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2013;
+},
+{
+glyphname = emdash;
+lastChange = "2022-02-14 13:12:49 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"98 117 OFFCURVE",
+"112 118 OFFCURVE",
+"146 120 CURVE SMOOTH",
+"258 127 OFFCURVE",
+"395 130 OFFCURVE",
+"558 130 CURVE SMOOTH",
+"567 130 OFFCURVE",
+"571 131 OFFCURVE",
+"571 134 CURVE SMOOTH",
+"571 136 OFFCURVE",
+"569 137 OFFCURVE",
+"563 138 CURVE",
+"518 142 OFFCURVE",
+"482 144 OFFCURVE",
+"458 144 CURVE SMOOTH",
+"395 147 OFFCURVE",
+"331 149 OFFCURVE",
+"266 149 CURVE SMOOTH",
+"217 149 OFFCURVE",
+"174 147 OFFCURVE",
+"138 146 CURVE SMOOTH",
+"99 144 OFFCURVE",
+"79 142 OFFCURVE",
+"78 141 CURVE",
+"81 131 OFFCURVE",
+"98 117 OFFCURVE",
+"106 117 CURVE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"98 117 OFFCURVE",
+"112 118 OFFCURVE",
+"146 120 CURVE SMOOTH",
+"258 127 OFFCURVE",
+"395 130 OFFCURVE",
+"558 130 CURVE SMOOTH",
+"567 130 OFFCURVE",
+"571 131 OFFCURVE",
+"571 134 CURVE SMOOTH",
+"571 136 OFFCURVE",
+"569 137 OFFCURVE",
+"563 138 CURVE SMOOTH",
+"518 142 OFFCURVE",
+"482 144 OFFCURVE",
+"458 144 CURVE SMOOTH",
+"395 147 OFFCURVE",
+"331 149 OFFCURVE",
+"266 149 CURVE SMOOTH",
+"217 149 OFFCURVE",
+"174 147 OFFCURVE",
+"138 146 CURVE SMOOTH",
+"99 144 OFFCURVE",
+"79 142 OFFCURVE",
+"78 141 CURVE",
+"81 131 OFFCURVE",
+"98 117 OFFCURVE",
+"106 117 CURVE"
+);
+}
+);
+width = 601;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+note = emdash;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2014;
+},
+{
+glyphname = hyphentwo;
+lastChange = "2022-02-14 13:12:49 +0000";
+layers = (
+{
+background = {
+components = (
+{
+name = hyphen;
+}
+);
+};
+components = (
+{
+name = hyphen;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 311;
+}
+);
+leftKerningGroup = hyphen;
+leftMetricsKey = hyphen;
+rightKerningGroup = hyphen;
+rightMetricsKey = hyphen;
+unicode = 2010;
+},
+{
+glyphname = underscore;
+lastChange = "2022-02-14 09:46:18 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"560 -100 LINE",
+"560 -75 LINE",
+"-10 -75 LINE",
+"-10 -100 LINE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"560 -100 LINE",
+"560 -75 LINE",
+"-10 -75 LINE",
+"-10 -100 LINE"
+);
+}
+);
+width = 570;
+}
+);
+note = underscore;
+unicode = 005F;
 },
 {
 color = 3;
@@ -49574,8 +49510,8 @@ rightKerningGroup = quotes;
 unicode = 0027;
 },
 {
-glyphname = florin;
-lastChange = "2022-02-14 21:32:36 +0000";
+glyphname = "leftanglebracket-math";
+lastChange = "2022-02-14 09:32:40 +0000";
 layers = (
 {
 background = {
@@ -49583,71 +49519,31 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-25 -261 OFFCURVE",
-"14 -181 OFFCURVE",
-"101 104 CURVE",
-"121 106 OFFCURVE",
-"139 107 OFFCURVE",
-"153 107 CURVE SMOOTH",
-"156 107 OFFCURVE",
-"157 108 OFFCURVE",
-"157 109 CURVE SMOOTH",
-"157 114 OFFCURVE",
-"140 118 OFFCURVE",
-"106 119 CURVE",
-"132 188 OFFCURVE",
-"151 237 OFFCURVE",
-"165 266 CURVE SMOOTH",
-"201 341 OFFCURVE",
-"231 380 OFFCURVE",
-"256 380 CURVE SMOOTH",
-"272 380 OFFCURVE",
-"280 363 OFFCURVE",
-"280 330 CURVE SMOOTH",
-"280 320 LINE SMOOTH",
-"280 314 OFFCURVE",
-"281 312 OFFCURVE",
-"282 312 CURVE SMOOTH",
-"289 312 OFFCURVE",
-"294 321 OFFCURVE",
-"294 341 CURVE SMOOTH",
-"294 368 OFFCURVE",
-"272 388 OFFCURVE",
-"243 388 CURVE SMOOTH",
-"194 388 OFFCURVE",
-"151 332 OFFCURVE",
-"113 220 CURVE SMOOTH",
-"100 175 OFFCURVE",
-"90 141 OFFCURVE",
-"83 119 CURVE",
-"68 118 OFFCURVE",
-"52 117 OFFCURVE",
-"34 114 CURVE",
-"33 113 LINE",
-"35 104 OFFCURVE",
-"40 100 OFFCURVE",
-"46 100 CURVE SMOOTH",
-"41 100 OFFCURVE",
-"52 100 OFFCURVE",
-"79 102 CURVE",
-"69 65 OFFCURVE",
-"59 36 OFFCURVE",
-"47 0 CURVE SMOOTH",
-"-6 -162 OFFCURVE",
-"-64 -244 OFFCURVE",
-"-128 -244 CURVE SMOOTH",
-"-156 -244 OFFCURVE",
-"-173 -212 OFFCURVE",
-"-179 -145 CURVE SMOOTH",
-"-180 -139 OFFCURVE",
-"-181 -134 OFFCURVE",
-"-183 -134 CURVE SMOOTH",
-"-193 -134 OFFCURVE",
-"-198 -148 OFFCURVE",
-"-198 -177 CURVE SMOOTH",
-"-198 -223 OFFCURVE",
-"-166 -261 OFFCURVE",
-"-121 -261 CURVE SMOOTH"
+"295 -80 OFFCURVE",
+"298 -75 OFFCURVE",
+"299 -66 CURVE SMOOTH",
+"300 -60 OFFCURVE",
+"234 90 OFFCURVE",
+"174 244 CURVE",
+"243 357 OFFCURVE",
+"412 606 OFFCURVE",
+"422 622 CURVE SMOOTH",
+"434 639 OFFCURVE",
+"420 641 OFFCURVE",
+"415 641 CURVE SMOOTH",
+"409 641 OFFCURVE",
+"401 637 OFFCURVE",
+"394 630 CURVE SMOOTH",
+"358 592 OFFCURVE",
+"184 326 OFFCURVE",
+"154 277 CURVE SMOOTH",
+"139 253 OFFCURVE",
+"121 231 OFFCURVE",
+"130 212 CURVE",
+"202 68 OFFCURVE",
+"268 -54 OFFCURVE",
+"281 -75 CURVE",
+"289 -79 LINE"
 );
 }
 );
@@ -49657,80 +49553,47 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-25 -261 OFFCURVE",
-"14 -181 OFFCURVE",
-"101 104 CURVE",
-"121 106 OFFCURVE",
-"139 107 OFFCURVE",
-"153 107 CURVE SMOOTH",
-"156 107 OFFCURVE",
-"157 108 OFFCURVE",
-"157 109 CURVE SMOOTH",
-"157 114 OFFCURVE",
-"140 118 OFFCURVE",
-"106 119 CURVE",
-"132 188 OFFCURVE",
-"151 237 OFFCURVE",
-"165 266 CURVE SMOOTH",
-"201 341 OFFCURVE",
-"231 380 OFFCURVE",
-"256 380 CURVE SMOOTH",
-"272 380 OFFCURVE",
-"280 363 OFFCURVE",
-"280 330 CURVE SMOOTH",
-"280 320 LINE SMOOTH",
-"280 314 OFFCURVE",
-"281 312 OFFCURVE",
-"282 312 CURVE SMOOTH",
-"289 312 OFFCURVE",
-"294 321 OFFCURVE",
-"294 341 CURVE SMOOTH",
-"294 368 OFFCURVE",
-"272 388 OFFCURVE",
-"243 388 CURVE SMOOTH",
-"194 388 OFFCURVE",
-"151 332 OFFCURVE",
-"113 220 CURVE SMOOTH",
-"83 119 LINE",
-"68 118 OFFCURVE",
-"52 117 OFFCURVE",
-"34 114 CURVE",
-"33 113 LINE",
-"35 103 OFFCURVE",
-"45 100 OFFCURVE",
-"45 100 CURVE",
-"45 100 OFFCURVE",
-"56 100 OFFCURVE",
-"79 102 CURVE",
-"69 65 OFFCURVE",
-"59 36 OFFCURVE",
-"47 0 CURVE SMOOTH",
-"-6 -162 OFFCURVE",
-"-64 -244 OFFCURVE",
-"-128 -244 CURVE SMOOTH",
-"-156 -244 OFFCURVE",
-"-173 -212 OFFCURVE",
-"-179 -145 CURVE SMOOTH",
-"-180 -139 OFFCURVE",
-"-181 -134 OFFCURVE",
-"-183 -134 CURVE SMOOTH",
-"-193 -134 OFFCURVE",
-"-198 -148 OFFCURVE",
-"-198 -177 CURVE SMOOTH",
-"-198 -223 OFFCURVE",
-"-166 -261 OFFCURVE",
-"-121 -261 CURVE SMOOTH"
+"295 -80 OFFCURVE",
+"298 -75 OFFCURVE",
+"299 -66 CURVE SMOOTH",
+"300 -60 OFFCURVE",
+"234 90 OFFCURVE",
+"174 244 CURVE",
+"243 357 OFFCURVE",
+"412 606 OFFCURVE",
+"422 622 CURVE SMOOTH",
+"425 626 OFFCURVE",
+"427 630 OFFCURVE",
+"427 633 CURVE SMOOTH",
+"427 640 OFFCURVE",
+"419 641 OFFCURVE",
+"415 641 CURVE SMOOTH",
+"409 641 OFFCURVE",
+"401 637 OFFCURVE",
+"394 630 CURVE SMOOTH",
+"358 592 OFFCURVE",
+"184 326 OFFCURVE",
+"154 277 CURVE SMOOTH",
+"142 257 OFFCURVE",
+"128 239 OFFCURVE",
+"128 222 CURVE SMOOTH",
+"128 219 OFFCURVE",
+"128 216 OFFCURVE",
+"130 212 CURVE SMOOTH",
+"202 68 OFFCURVE",
+"268 -54 OFFCURVE",
+"281 -75 CURVE",
+"289 -79 LINE"
 );
 }
 );
-width = 292;
+width = 495;
 }
 );
-note = florin;
-unicode = 0192;
+unicode = 27E8;
 },
 {
-glyphname = apple;
+glyphname = "rightanglebracket-math";
 lastChange = "2022-02-07 18:28:46 +0000";
 layers = (
 {
@@ -49739,89 +49602,31 @@ paths = (
 {
 closed = 1;
 nodes = (
-"229 83 OFFCURVE",
-"247 88 OFFCURVE",
-"260 99 CURVE",
-"272 106 OFFCURVE",
-"288 110 OFFCURVE",
-"306 110 CURVE SMOOTH",
-"326 110 OFFCURVE",
-"341 106 OFFCURVE",
-"354 99 CURVE SMOOTH",
-"370 88 OFFCURVE",
-"387 83 OFFCURVE",
-"408 83 CURVE SMOOTH",
-"430 83 OFFCURVE",
-"458 102 OFFCURVE",
-"490 141 CURVE SMOOTH",
-"518 175 OFFCURVE",
-"537 208 OFFCURVE",
-"546 240 CURVE",
-"492 261 OFFCURVE",
-"464 304 OFFCURVE",
-"464 365 CURVE SMOOTH",
-"464 417 OFFCURVE",
-"487 456 OFFCURVE",
-"531 481 CURVE",
-"504 522 OFFCURVE",
-"467 542 OFFCURVE",
-"421 542 CURVE SMOOTH",
-"409 542 OFFCURVE",
-"400 542 OFFCURVE",
-"395 540 CURVE SMOOTH",
-"382 534 OFFCURVE",
-"361 527 OFFCURVE",
-"333 520 CURVE SMOOTH",
-"322 517 OFFCURVE",
-"311 516 OFFCURVE",
-"301 516 CURVE SMOOTH",
-"295 516 OFFCURVE",
-"288 516 OFFCURVE",
-"282 518 CURVE SMOOTH",
-"258 526 OFFCURVE",
-"236 533 OFFCURVE",
-"219 540 CURVE SMOOTH",
-"216 541 OFFCURVE",
-"210 542 OFFCURVE",
-"199 542 CURVE SMOOTH",
-"149 542 OFFCURVE",
-"108 514 OFFCURVE",
-"78 461 CURVE SMOOTH",
-"60 429 OFFCURVE",
-"52 393 OFFCURVE",
-"52 351 CURVE SMOOTH",
-"52 270 OFFCURVE",
-"76 200 OFFCURVE",
-"124 141 CURVE SMOOTH",
-"156 102 OFFCURVE",
-"183 83 OFFCURVE",
-"207 83 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"341 532 OFFCURVE",
-"369 546 OFFCURVE",
-"392 575 CURVE SMOOTH",
-"413 602 OFFCURVE",
-"423 631 OFFCURVE",
-"423 663 CURVE SMOOTH",
-"423 673 OFFCURVE",
-"422 679 OFFCURVE",
-"422 681 CURVE",
-"413 684 OFFCURVE",
-"401 681 OFFCURVE",
-"384 672 CURVE SMOOTH",
-"371 665 OFFCURVE",
-"360 658 OFFCURVE",
-"351 649 CURVE SMOOTH",
-"323 621 OFFCURVE",
-"308 586 OFFCURVE",
-"308 548 CURVE SMOOTH",
-"308 543 OFFCURVE",
-"309 539 OFFCURVE",
-"311 533 CURVE"
+"229 642 OFFCURVE",
+"226 637 OFFCURVE",
+"225 628 CURVE SMOOTH",
+"224 622 OFFCURVE",
+"291 472 OFFCURVE",
+"350 318 CURVE",
+"282 205 OFFCURVE",
+"113 -44 OFFCURVE",
+"102 -60 CURVE SMOOTH",
+"91 -77 OFFCURVE",
+"104 -79 OFFCURVE",
+"109 -79 CURVE SMOOTH",
+"116 -79 OFFCURVE",
+"124 -75 OFFCURVE",
+"131 -68 CURVE SMOOTH",
+"167 -30 OFFCURVE",
+"341 236 OFFCURVE",
+"371 285 CURVE SMOOTH",
+"385 309 OFFCURVE",
+"404 331 OFFCURVE",
+"395 350 CURVE",
+"323 494 OFFCURVE",
+"257 616 OFFCURVE",
+"244 637 CURVE",
+"236 641 LINE"
 );
 }
 );
@@ -49831,3375 +49636,44 @@ paths = (
 {
 closed = 1;
 nodes = (
-"229 83 OFFCURVE",
-"247 88 OFFCURVE",
-"260 99 CURVE",
-"272 106 OFFCURVE",
-"288 110 OFFCURVE",
-"306 110 CURVE SMOOTH",
-"326 110 OFFCURVE",
-"341 106 OFFCURVE",
-"354 99 CURVE SMOOTH",
-"370 88 OFFCURVE",
-"387 83 OFFCURVE",
-"408 83 CURVE SMOOTH",
-"430 83 OFFCURVE",
-"458 102 OFFCURVE",
-"490 141 CURVE SMOOTH",
-"518 175 OFFCURVE",
-"537 208 OFFCURVE",
-"546 240 CURVE",
-"492 261 OFFCURVE",
-"464 304 OFFCURVE",
-"464 365 CURVE SMOOTH",
-"464 417 OFFCURVE",
-"487 456 OFFCURVE",
-"531 481 CURVE",
-"504 522 OFFCURVE",
-"467 542 OFFCURVE",
-"421 542 CURVE SMOOTH",
-"409 542 OFFCURVE",
-"400 542 OFFCURVE",
-"395 540 CURVE SMOOTH",
-"382 534 OFFCURVE",
-"361 527 OFFCURVE",
-"333 520 CURVE SMOOTH",
-"322 517 OFFCURVE",
-"311 516 OFFCURVE",
-"301 516 CURVE SMOOTH",
-"295 516 OFFCURVE",
-"288 516 OFFCURVE",
-"282 518 CURVE SMOOTH",
-"258 526 OFFCURVE",
-"236 533 OFFCURVE",
-"219 540 CURVE SMOOTH",
-"216 541 OFFCURVE",
-"210 542 OFFCURVE",
-"199 542 CURVE SMOOTH",
-"149 542 OFFCURVE",
-"108 514 OFFCURVE",
-"78 461 CURVE SMOOTH",
-"60 429 OFFCURVE",
-"52 393 OFFCURVE",
-"52 351 CURVE SMOOTH",
-"52 270 OFFCURVE",
-"76 200 OFFCURVE",
-"124 141 CURVE SMOOTH",
-"156 102 OFFCURVE",
-"183 83 OFFCURVE",
-"207 83 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"341 532 OFFCURVE",
-"369 546 OFFCURVE",
-"392 575 CURVE SMOOTH",
-"413 602 OFFCURVE",
-"423 631 OFFCURVE",
-"423 663 CURVE SMOOTH",
-"423 673 OFFCURVE",
-"422 679 OFFCURVE",
-"422 681 CURVE",
-"413 684 OFFCURVE",
-"401 681 OFFCURVE",
-"384 672 CURVE SMOOTH",
-"371 665 OFFCURVE",
-"360 658 OFFCURVE",
-"351 649 CURVE SMOOTH",
-"323 621 OFFCURVE",
-"308 586 OFFCURVE",
-"308 548 CURVE SMOOTH",
-"308 543 OFFCURVE",
-"309 539 OFFCURVE",
-"311 533 CURVE"
-);
-}
-);
-width = 577;
-}
-);
-note = apple;
-unicode = F8FF;
-},
-{
-color = 3;
-glyphname = at;
-lastChange = "2022-02-14 19:26:37 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"399 27 OFFCURVE",
-"470 43 OFFCURVE",
-"544 73 CURVE SMOOTH",
-"622 105 OFFCURVE",
-"682 146 OFFCURVE",
-"722 196 CURVE SMOOTH",
-"752 230 OFFCURVE",
-"766 263 OFFCURVE",
-"766 296 CURVE SMOOTH",
-"766 339 OFFCURVE",
-"751 377 OFFCURVE",
-"720 410 CURVE",
-"721 420 OFFCURVE",
-"722 429 OFFCURVE",
-"722 438 CURVE SMOOTH",
-"722 500 OFFCURVE",
-"702 546 OFFCURVE",
-"662 581 CURVE SMOOTH",
-"625 613 OFFCURVE",
-"575 629 OFFCURVE",
-"514 629 CURVE SMOOTH",
-"409 629 OFFCURVE",
-"311 594 OFFCURVE",
-"218 523 CURVE SMOOTH",
-"119 447 OFFCURVE",
-"70 358 OFFCURVE",
-"70 258 CURVE SMOOTH",
-"70 219 OFFCURVE",
-"78 181 OFFCURVE",
-"93 145 CURVE SMOOTH",
-"111 105 OFFCURVE",
-"144 75 OFFCURVE",
-"194 54 CURVE SMOOTH",
-"235 36 OFFCURVE",
-"280 27 OFFCURVE",
-"330 27 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"236 175 OFFCURVE",
-"226 184 OFFCURVE",
-"226 203 CURVE SMOOTH",
-"226 247 OFFCURVE",
-"260 311 OFFCURVE",
-"328 394 CURVE SMOOTH",
-"397 477 OFFCURVE",
-"452 519 OFFCURVE",
-"495 519 CURVE SMOOTH",
-"512 519 OFFCURVE",
-"521 509 OFFCURVE",
-"521 491 CURVE SMOOTH",
-"521 472 OFFCURVE",
-"514 455 OFFCURVE",
-"501 436 CURVE",
-"506 448 OFFCURVE",
-"508 457 OFFCURVE",
-"508 463 CURVE SMOOTH",
-"508 471 OFFCURVE",
-"505 475 OFFCURVE",
-"499 475 CURVE SMOOTH",
-"485 475 OFFCURVE",
-"471 463 OFFCURVE",
-"454 440 CURVE SMOOTH",
-"438 418 OFFCURVE",
-"429 398 OFFCURVE",
-"427 383 CURVE",
-"388 361 LINE",
-"376 357 OFFCURVE",
-"370 353 OFFCURVE",
-"370 349 CURVE SMOOTH",
-"370 346 OFFCURVE",
-"372 344 OFFCURVE",
-"376 344 CURVE SMOOTH",
-"385 344 OFFCURVE",
-"396 346 OFFCURVE",
-"408 351 CURVE",
-"359 233 OFFCURVE",
-"307 175 OFFCURVE",
-"254 175 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"263 42 OFFCURVE",
-"208 57 OFFCURVE",
-"166 86 CURVE SMOOTH",
-"118 120 OFFCURVE",
-"93 169 OFFCURVE",
-"93 233 CURVE SMOOTH",
-"93 326 OFFCURVE",
-"145 411 OFFCURVE",
-"248 489 CURVE SMOOTH",
-"345 562 OFFCURVE",
-"441 599 OFFCURVE",
-"538 599 CURVE SMOOTH",
-"626 599 OFFCURVE",
-"679 563 OFFCURVE",
-"696 492 CURVE SMOOTH",
-"698 483 OFFCURVE",
-"699 473 OFFCURVE",
-"699 464 CURVE SMOOTH",
-"699 454 OFFCURVE",
-"698 443 OFFCURVE",
-"695 431 CURVE",
-"674 446 OFFCURVE",
-"653 453 OFFCURVE",
-"634 453 CURVE SMOOTH",
-"623 453 OFFCURVE",
-"618 450 OFFCURVE",
-"618 445 CURVE SMOOTH",
-"618 444 OFFCURVE",
-"619 444 OFFCURVE",
-"620 443 CURVE",
-"648 430 OFFCURVE",
-"670 414 OFFCURVE",
-"686 393 CURVE",
-"679 364 OFFCURVE",
-"667 333 OFFCURVE",
-"650 300 CURVE SMOOTH",
-"632 263 OFFCURVE",
-"610 229 OFFCURVE",
-"584 195 CURVE SMOOTH",
-"547 148 OFFCURVE",
-"516 125 OFFCURVE",
-"490 125 CURVE SMOOTH",
-"464 125 OFFCURVE",
-"451 152 OFFCURVE",
-"451 206 CURVE SMOOTH",
-"451 271 OFFCURVE",
-"463 334 OFFCURVE",
-"487 393 CURVE",
-"535 428 OFFCURVE",
-"560 463 OFFCURVE",
-"560 500 CURVE SMOOTH",
-"560 528 OFFCURVE",
-"543 542 OFFCURVE",
-"510 542 CURVE SMOOTH",
-"483 542 OFFCURVE",
-"453 534 OFFCURVE",
-"418 517 CURVE SMOOTH",
-"363 492 OFFCURVE",
-"314 448 OFFCURVE",
-"269 385 CURVE SMOOTH",
-"221 320 OFFCURVE",
-"198 260 OFFCURVE",
-"198 202 CURVE SMOOTH",
-"198 157 OFFCURVE",
-"215 135 OFFCURVE",
-"249 135 CURVE SMOOTH",
-"305 135 OFFCURVE",
-"360 194 OFFCURVE",
-"413 312 CURVE",
-"404 275 OFFCURVE",
-"401 244 OFFCURVE",
-"401 219 CURVE SMOOTH",
-"401 206 OFFCURVE",
-"401 194 OFFCURVE",
-"403 184 CURVE SMOOTH",
-"411 144 OFFCURVE",
-"444 105 OFFCURVE",
-"482 105 CURVE SMOOTH",
-"524 105 OFFCURVE",
-"569 140 OFFCURVE",
-"618 209 CURVE SMOOTH",
-"657 264 OFFCURVE",
-"685 318 OFFCURVE",
-"702 370 CURVE",
-"714 347 OFFCURVE",
-"720 325 OFFCURVE",
-"720 301 CURVE SMOOTH",
-"720 289 OFFCURVE",
-"718 276 OFFCURVE",
-"714 264 CURVE SMOOTH",
-"690 197 OFFCURVE",
-"638 141 OFFCURVE",
-"557 100 CURVE SMOOTH",
-"483 61 OFFCURVE",
-"407 42 OFFCURVE",
-"330 42 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"399 -107 OFFCURVE",
-"470 -91 OFFCURVE",
-"544 -61 CURVE SMOOTH",
-"622 -29 OFFCURVE",
-"682 12 OFFCURVE",
-"722 62 CURVE SMOOTH",
-"752 96 OFFCURVE",
-"766 129 OFFCURVE",
-"766 162 CURVE SMOOTH",
-"766 205 OFFCURVE",
-"751 243 OFFCURVE",
-"720 276 CURVE",
-"721 286 OFFCURVE",
-"722 295 OFFCURVE",
-"722 304 CURVE SMOOTH",
-"722 366 OFFCURVE",
-"702 412 OFFCURVE",
-"662 447 CURVE SMOOTH",
-"625 479 OFFCURVE",
-"575 495 OFFCURVE",
-"514 495 CURVE SMOOTH",
-"409 495 OFFCURVE",
-"311 460 OFFCURVE",
-"218 389 CURVE SMOOTH",
-"119 313 OFFCURVE",
-"70 224 OFFCURVE",
-"70 124 CURVE SMOOTH",
-"70 85 OFFCURVE",
-"78 47 OFFCURVE",
-"93 11 CURVE SMOOTH",
-"111 -29 OFFCURVE",
-"144 -59 OFFCURVE",
-"194 -80 CURVE SMOOTH",
-"235 -98 OFFCURVE",
-"280 -107 OFFCURVE",
-"330 -107 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"236 41 OFFCURVE",
-"226 50 OFFCURVE",
-"226 69 CURVE SMOOTH",
-"226 113 OFFCURVE",
-"260 177 OFFCURVE",
-"328 260 CURVE SMOOTH",
+"116 -79 OFFCURVE",
+"124 -75 OFFCURVE",
+"131 -68 CURVE SMOOTH",
+"167 -30 OFFCURVE",
+"341 236 OFFCURVE",
+"371 285 CURVE SMOOTH",
+"382 305 OFFCURVE",
+"397 323 OFFCURVE",
+"397 340 CURVE SMOOTH",
 "397 343 OFFCURVE",
-"452 385 OFFCURVE",
-"495 385 CURVE SMOOTH",
-"512 385 OFFCURVE",
-"521 375 OFFCURVE",
-"521 357 CURVE SMOOTH",
-"521 338 OFFCURVE",
-"514 321 OFFCURVE",
-"501 302 CURVE",
-"506 314 OFFCURVE",
-"508 323 OFFCURVE",
-"508 329 CURVE SMOOTH",
-"508 337 OFFCURVE",
-"505 341 OFFCURVE",
-"499 341 CURVE SMOOTH",
-"485 341 OFFCURVE",
-"471 329 OFFCURVE",
-"454 306 CURVE SMOOTH",
-"438 284 OFFCURVE",
-"429 264 OFFCURVE",
-"427 249 CURVE",
-"388 227 LINE",
-"376 223 OFFCURVE",
-"370 219 OFFCURVE",
-"370 215 CURVE SMOOTH",
-"370 212 OFFCURVE",
-"372 210 OFFCURVE",
-"376 210 CURVE SMOOTH",
-"385 210 OFFCURVE",
-"396 212 OFFCURVE",
-"408 217 CURVE",
-"359 99 OFFCURVE",
-"307 41 OFFCURVE",
-"254 41 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"263 -92 OFFCURVE",
-"208 -77 OFFCURVE",
-"166 -48 CURVE SMOOTH",
-"118 -14 OFFCURVE",
-"93 35 OFFCURVE",
-"93 99 CURVE SMOOTH",
-"93 192 OFFCURVE",
-"145 277 OFFCURVE",
-"248 355 CURVE SMOOTH",
-"345 428 OFFCURVE",
-"441 465 OFFCURVE",
-"538 465 CURVE SMOOTH",
-"626 465 OFFCURVE",
-"679 429 OFFCURVE",
-"696 358 CURVE SMOOTH",
-"698 349 OFFCURVE",
-"699 339 OFFCURVE",
-"699 330 CURVE SMOOTH",
-"699 320 OFFCURVE",
-"698 309 OFFCURVE",
-"695 297 CURVE",
-"674 312 OFFCURVE",
-"653 319 OFFCURVE",
-"634 319 CURVE SMOOTH",
-"623 319 OFFCURVE",
-"618 316 OFFCURVE",
-"618 311 CURVE SMOOTH",
-"618 310 OFFCURVE",
-"619 310 OFFCURVE",
-"620 309 CURVE",
-"648 296 OFFCURVE",
-"670 280 OFFCURVE",
-"686 259 CURVE",
-"679 230 OFFCURVE",
-"667 199 OFFCURVE",
-"650 166 CURVE SMOOTH",
-"632 129 OFFCURVE",
-"610 95 OFFCURVE",
-"584 61 CURVE SMOOTH",
-"547 14 OFFCURVE",
-"516 -9 OFFCURVE",
-"490 -9 CURVE SMOOTH",
-"464 -9 OFFCURVE",
-"451 18 OFFCURVE",
-"451 72 CURVE SMOOTH",
-"451 137 OFFCURVE",
-"463 200 OFFCURVE",
-"487 259 CURVE",
-"535 294 OFFCURVE",
-"560 329 OFFCURVE",
-"560 366 CURVE SMOOTH",
-"560 394 OFFCURVE",
-"543 408 OFFCURVE",
-"510 408 CURVE SMOOTH",
-"483 408 OFFCURVE",
-"453 400 OFFCURVE",
-"418 383 CURVE SMOOTH",
-"363 358 OFFCURVE",
-"314 314 OFFCURVE",
-"269 251 CURVE SMOOTH",
-"221 186 OFFCURVE",
-"198 126 OFFCURVE",
-"198 68 CURVE SMOOTH",
-"198 23 OFFCURVE",
-"215 1 OFFCURVE",
-"249 1 CURVE SMOOTH",
-"305 1 OFFCURVE",
-"360 60 OFFCURVE",
-"413 178 CURVE",
-"404 141 OFFCURVE",
-"401 110 OFFCURVE",
-"401 85 CURVE SMOOTH",
-"401 72 OFFCURVE",
-"401 60 OFFCURVE",
-"403 50 CURVE SMOOTH",
-"411 10 OFFCURVE",
-"444 -29 OFFCURVE",
-"482 -29 CURVE SMOOTH",
-"524 -29 OFFCURVE",
-"569 6 OFFCURVE",
-"618 75 CURVE SMOOTH",
-"657 130 OFFCURVE",
-"685 184 OFFCURVE",
-"702 236 CURVE",
-"714 213 OFFCURVE",
-"720 191 OFFCURVE",
-"720 167 CURVE SMOOTH",
-"720 155 OFFCURVE",
-"718 142 OFFCURVE",
-"714 130 CURVE SMOOTH",
-"690 63 OFFCURVE",
-"638 7 OFFCURVE",
-"557 -34 CURVE SMOOTH",
-"483 -73 OFFCURVE",
-"407 -92 OFFCURVE",
-"330 -92 CURVE SMOOTH"
+"397 346 OFFCURVE",
+"395 350 CURVE SMOOTH",
+"323 494 OFFCURVE",
+"257 616 OFFCURVE",
+"244 637 CURVE",
+"236 641 LINE",
+"229 642 OFFCURVE",
+"226 637 OFFCURVE",
+"225 628 CURVE SMOOTH",
+"224 622 OFFCURVE",
+"291 472 OFFCURVE",
+"350 318 CURVE",
+"282 205 OFFCURVE",
+"113 -44 OFFCURVE",
+"102 -60 CURVE SMOOTH",
+"100 -64 OFFCURVE",
+"98 -68 OFFCURVE",
+"98 -71 CURVE SMOOTH",
+"98 -78 OFFCURVE",
+"105 -79 OFFCURVE",
+"109 -79 CURVE SMOOTH"
 );
 }
 );
-width = 786;
+width = 495;
 }
 );
-note = at;
-unicode = 0040;
-},
-{
-glyphname = ampersand;
-lastChange = "2022-02-14 19:24:06 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"304 -236 OFFCURVE",
-"384 -145 OFFCURVE",
-"440 35 CURVE",
-"536 65 OFFCURVE",
-"615 115 OFFCURVE",
-"677 186 CURVE SMOOTH",
-"723 239 OFFCURVE",
-"746 283 OFFCURVE",
-"746 317 CURVE SMOOTH",
-"746 357 OFFCURVE",
-"719 378 OFFCURVE",
-"665 378 CURVE SMOOTH",
-"613 378 OFFCURVE",
-"558 359 OFFCURVE",
-"503 321 CURVE",
-"520 403 OFFCURVE",
-"534 458 OFFCURVE",
-"544 484 CURVE",
-"622 530 OFFCURVE",
-"661 569 OFFCURVE",
-"661 602 CURVE SMOOTH",
-"661 622 OFFCURVE",
-"652 631 OFFCURVE",
-"635 631 CURVE SMOOTH",
-"621 631 OFFCURVE",
-"603 622 OFFCURVE",
-"584 601 CURVE SMOOTH",
-"571 588 OFFCURVE",
-"558 570 OFFCURVE",
-"546 544 CURVE SMOOTH",
-"541 532 OFFCURVE",
-"532 510 OFFCURVE",
-"521 480 CURVE",
-"458 447 OFFCURVE",
-"394 414 OFFCURVE",
-"331 380 CURVE SMOOTH",
-"260 341 OFFCURVE",
-"201 301 OFFCURVE",
-"153 257 CURVE",
-"133 279 OFFCURVE",
-"122 304 OFFCURVE",
-"122 335 CURVE SMOOTH",
-"122 382 OFFCURVE",
-"147 423 OFFCURVE",
-"198 458 CURVE SMOOTH",
-"243 488 OFFCURVE",
-"291 503 OFFCURVE",
-"342 503 CURVE SMOOTH",
-"356 503 OFFCURVE",
-"389 495 OFFCURVE",
-"402 495 CURVE SMOOTH",
-"403 495 OFFCURVE",
-"404 496 OFFCURVE",
-"405 498 CURVE",
-"405 506 OFFCURVE",
-"383 511 OFFCURVE",
-"338 511 CURVE SMOOTH",
-"282 511 OFFCURVE",
-"229 495 OFFCURVE",
-"179 462 CURVE SMOOTH",
-"121 426 OFFCURVE",
-"93 382 OFFCURVE",
-"93 330 CURVE SMOOTH",
-"93 295 OFFCURVE",
-"106 264 OFFCURVE",
-"134 239 CURVE",
-"82 187 OFFCURVE",
-"57 142 OFFCURVE",
-"57 103 CURVE SMOOTH",
-"57 65 OFFCURVE",
-"80 37 OFFCURVE",
-"128 20 CURVE SMOOTH",
-"162 7 OFFCURVE",
-"202 0 OFFCURVE",
-"248 0 CURVE SMOOTH",
-"294 0 OFFCURVE",
-"342 6 OFFCURVE",
-"391 19 CURVE",
-"332 -142 OFFCURVE",
-"264 -222 OFFCURVE",
-"190 -222 CURVE SMOOTH",
-"152 -222 OFFCURVE",
-"130 -206 OFFCURVE",
-"125 -173 CURVE",
-"124 -170 OFFCURVE",
-"123 -169 OFFCURVE",
-"121 -169 CURVE SMOOTH",
-"118 -169 OFFCURVE",
-"117 -170 OFFCURVE",
-"117 -173 CURVE SMOOTH",
-"117 -193 OFFCURVE",
-"127 -209 OFFCURVE",
-"145 -221 CURVE SMOOTH",
-"161 -231 OFFCURVE",
-"180 -236 OFFCURVE",
-"202 -236 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"243 20 OFFCURVE",
-"208 26 OFFCURVE",
-"179 38 CURVE SMOOTH",
-"139 55 OFFCURVE",
-"119 81 OFFCURVE",
-"119 116 CURVE SMOOTH",
-"119 145 OFFCURVE",
-"134 179 OFFCURVE",
-"164 217 CURVE",
-"191 201 OFFCURVE",
-"221 193 OFFCURVE",
-"252 193 CURVE SMOOTH",
-"314 193 OFFCURVE",
-"386 226 OFFCURVE",
-"468 292 CURVE",
-"439 173 OFFCURVE",
-"415 87 OFFCURVE",
-"395 34 CURVE",
-"357 25 OFFCURVE",
-"320 20 OFFCURVE",
-"284 20 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"230 213 OFFCURVE",
-"204 221 OFFCURVE",
-"180 235 CURVE",
-"231 293 OFFCURVE",
-"297 345 OFFCURVE",
-"376 392 CURVE SMOOTH",
-"438 426 OFFCURVE",
-"485 452 OFFCURVE",
-"517 468 CURVE",
-"504 426 OFFCURVE",
-"488 371 OFFCURVE",
-"471 301 CURVE",
-"378 242 OFFCURVE",
-"306 213 OFFCURVE",
-"259 213 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"470 164 OFFCURVE",
-"489 251 OFFCURVE",
-"500 309 CURVE",
-"543 332 OFFCURVE",
-"585 342 OFFCURVE",
-"628 342 CURVE SMOOTH",
-"682 342 OFFCURVE",
-"709 325 OFFCURVE",
-"709 289 CURVE SMOOTH",
-"709 261 OFFCURVE",
-"689 222 OFFCURVE",
-"649 177 CURVE SMOOTH",
-"598 119 OFFCURVE",
-"530 76 OFFCURVE",
-"443 50 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"571 542 OFFCURVE",
-"588 572 OFFCURVE",
-"604 586 CURVE SMOOTH",
-"618 599 OFFCURVE",
-"627 605 OFFCURVE",
-"634 605 CURVE SMOOTH",
-"639 605 OFFCURVE",
-"642 601 OFFCURVE",
-"642 594 CURVE SMOOTH",
-"642 583 OFFCURVE",
-"629 565 OFFCURVE",
-"604 541 CURVE SMOOTH",
-"584 520 OFFCURVE",
-"565 505 OFFCURVE",
-"550 497 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"304 -236 OFFCURVE",
-"384 -145 OFFCURVE",
-"440 35 CURVE",
-"536 65 OFFCURVE",
-"615 115 OFFCURVE",
-"677 186 CURVE SMOOTH",
-"723 239 OFFCURVE",
-"746 283 OFFCURVE",
-"746 317 CURVE SMOOTH",
-"746 357 OFFCURVE",
-"719 378 OFFCURVE",
-"665 378 CURVE SMOOTH",
-"613 378 OFFCURVE",
-"558 359 OFFCURVE",
-"503 321 CURVE",
-"520 403 OFFCURVE",
-"534 458 OFFCURVE",
-"544 484 CURVE",
-"622 530 OFFCURVE",
-"661 569 OFFCURVE",
-"661 602 CURVE SMOOTH",
-"661 622 OFFCURVE",
-"652 631 OFFCURVE",
-"635 631 CURVE SMOOTH",
-"621 631 OFFCURVE",
-"603 622 OFFCURVE",
-"584 601 CURVE SMOOTH",
-"571 588 OFFCURVE",
-"558 570 OFFCURVE",
-"546 544 CURVE SMOOTH",
-"541 532 OFFCURVE",
-"532 510 OFFCURVE",
-"521 480 CURVE",
-"458 447 OFFCURVE",
-"394 414 OFFCURVE",
-"331 380 CURVE SMOOTH",
-"260 341 OFFCURVE",
-"201 301 OFFCURVE",
-"153 257 CURVE",
-"133 279 OFFCURVE",
-"122 304 OFFCURVE",
-"122 335 CURVE SMOOTH",
-"122 382 OFFCURVE",
-"147 423 OFFCURVE",
-"198 458 CURVE SMOOTH",
-"243 488 OFFCURVE",
-"291 503 OFFCURVE",
-"342 503 CURVE SMOOTH",
-"356 503 OFFCURVE",
-"389 495 OFFCURVE",
-"402 495 CURVE SMOOTH",
-"403 495 OFFCURVE",
-"404 496 OFFCURVE",
-"405 498 CURVE",
-"405 506 OFFCURVE",
-"383 511 OFFCURVE",
-"338 511 CURVE SMOOTH",
-"282 511 OFFCURVE",
-"229 495 OFFCURVE",
-"179 462 CURVE SMOOTH",
-"121 426 OFFCURVE",
-"93 382 OFFCURVE",
-"93 330 CURVE SMOOTH",
-"93 295 OFFCURVE",
-"106 264 OFFCURVE",
-"134 239 CURVE",
-"82 187 OFFCURVE",
-"57 142 OFFCURVE",
-"57 103 CURVE SMOOTH",
-"57 65 OFFCURVE",
-"80 37 OFFCURVE",
-"128 20 CURVE SMOOTH",
-"162 7 OFFCURVE",
-"202 0 OFFCURVE",
-"248 0 CURVE SMOOTH",
-"294 0 OFFCURVE",
-"342 6 OFFCURVE",
-"391 19 CURVE",
-"332 -142 OFFCURVE",
-"264 -222 OFFCURVE",
-"190 -222 CURVE SMOOTH",
-"152 -222 OFFCURVE",
-"130 -206 OFFCURVE",
-"125 -173 CURVE",
-"124 -170 OFFCURVE",
-"123 -169 OFFCURVE",
-"121 -169 CURVE SMOOTH",
-"118 -169 OFFCURVE",
-"117 -170 OFFCURVE",
-"117 -173 CURVE SMOOTH",
-"117 -193 OFFCURVE",
-"127 -209 OFFCURVE",
-"145 -221 CURVE SMOOTH",
-"161 -231 OFFCURVE",
-"180 -236 OFFCURVE",
-"202 -236 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"243 20 OFFCURVE",
-"208 26 OFFCURVE",
-"179 38 CURVE SMOOTH",
-"139 55 OFFCURVE",
-"119 81 OFFCURVE",
-"119 116 CURVE SMOOTH",
-"119 145 OFFCURVE",
-"134 179 OFFCURVE",
-"164 217 CURVE",
-"191 201 OFFCURVE",
-"221 193 OFFCURVE",
-"252 193 CURVE SMOOTH",
-"314 193 OFFCURVE",
-"386 226 OFFCURVE",
-"468 292 CURVE",
-"439 173 OFFCURVE",
-"415 87 OFFCURVE",
-"395 34 CURVE",
-"357 25 OFFCURVE",
-"320 20 OFFCURVE",
-"284 20 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"230 213 OFFCURVE",
-"204 221 OFFCURVE",
-"180 235 CURVE",
-"231 293 OFFCURVE",
-"297 345 OFFCURVE",
-"376 392 CURVE SMOOTH",
-"438 426 OFFCURVE",
-"485 452 OFFCURVE",
-"517 468 CURVE",
-"504 426 OFFCURVE",
-"488 371 OFFCURVE",
-"471 301 CURVE",
-"378 242 OFFCURVE",
-"306 213 OFFCURVE",
-"259 213 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"470 164 OFFCURVE",
-"489 251 OFFCURVE",
-"500 309 CURVE",
-"543 332 OFFCURVE",
-"585 342 OFFCURVE",
-"628 342 CURVE SMOOTH",
-"682 342 OFFCURVE",
-"709 325 OFFCURVE",
-"709 289 CURVE SMOOTH",
-"709 261 OFFCURVE",
-"689 222 OFFCURVE",
-"649 177 CURVE SMOOTH",
-"598 119 OFFCURVE",
-"530 76 OFFCURVE",
-"443 50 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"571 542 OFFCURVE",
-"588 572 OFFCURVE",
-"604 586 CURVE SMOOTH",
-"618 599 OFFCURVE",
-"627 605 OFFCURVE",
-"634 605 CURVE SMOOTH",
-"639 605 OFFCURVE",
-"642 601 OFFCURVE",
-"642 594 CURVE SMOOTH",
-"642 583 OFFCURVE",
-"629 565 OFFCURVE",
-"604 541 CURVE SMOOTH",
-"584 520 OFFCURVE",
-"565 505 OFFCURVE",
-"550 497 CURVE"
-);
-}
-);
-width = 739;
-}
-);
-note = ampersand;
-unicode = 0026;
-},
-{
-glyphname = paragraph;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"76 -193 OFFCURVE",
-"111 -175 OFFCURVE",
-"142 -138 CURVE",
-"148 -138 LINE SMOOTH",
-"216 -141 OFFCURVE",
-"273 -78 OFFCURVE",
-"319 51 CURVE SMOOTH",
-"337 102 OFFCURVE",
-"364 211 OFFCURVE",
-"398 376 CURVE SMOOTH",
-"418 478 OFFCURVE",
-"436 549 OFFCURVE",
-"450 590 CURVE SMOOTH",
-"475 664 OFFCURVE",
-"502 703 OFFCURVE",
-"532 703 CURVE SMOOTH",
-"542 703 OFFCURVE",
-"546 708 OFFCURVE",
-"544 721 CURVE SMOOTH",
-"544 731 OFFCURVE",
-"536 736 OFFCURVE",
-"523 736 CURVE SMOOTH",
-"492 736 OFFCURVE",
-"462 708 OFFCURVE",
-"437 655 CURVE",
-"424 649 OFFCURVE",
-"406 646 OFFCURVE",
-"382 646 CURVE SMOOTH",
-"326 646 OFFCURVE",
-"275 633 OFFCURVE",
-"231 609 CURVE SMOOTH",
-"178 579 OFFCURVE",
-"142 534 OFFCURVE",
-"121 474 CURVE SMOOTH",
-"108 437 OFFCURVE",
-"104 399 OFFCURVE",
-"108 361 CURVE SMOOTH",
-"113 316 OFFCURVE",
-"129 282 OFFCURVE",
-"156 256 CURVE SMOOTH",
-"179 233 OFFCURVE",
-"207 221 OFFCURVE",
-"238 217 CURVE",
-"212 103 OFFCURVE",
-"189 20 OFFCURVE",
-"168 -31 CURVE SMOOTH",
-"128 -124 OFFCURVE",
-"81 -170 OFFCURVE",
-"26 -170 CURVE SMOOTH",
-"14 -170 OFFCURVE",
-"9 -173 OFFCURVE",
-"10 -180 CURVE SMOOTH",
-"10 -189 OFFCURVE",
-"19 -193 OFFCURVE",
-"37 -193 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"190 -69 OFFCURVE",
-"221 11 OFFCURVE",
-"251 122 CURVE SMOOTH",
-"317 406 LINE SMOOTH",
-"343 507 OFFCURVE",
-"370 574 OFFCURVE",
-"398 607 CURVE",
-"419 609 LINE",
-"408 576 OFFCURVE",
-"397 537 OFFCURVE",
-"387 491 CURVE SMOOTH",
-"380 466 OFFCURVE",
-"372 425 OFFCURVE",
-"362 366 CURVE SMOOTH",
-"343 275 OFFCURVE",
-"332 215 OFFCURVE",
-"325 183 CURVE SMOOTH",
-"282 -10 OFFCURVE",
-"224 -111 OFFCURVE",
-"156 -120 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"76 -193 OFFCURVE",
-"111 -175 OFFCURVE",
-"142 -138 CURVE",
-"148 -138 LINE SMOOTH",
-"216 -141 OFFCURVE",
-"273 -78 OFFCURVE",
-"319 51 CURVE SMOOTH",
-"337 102 OFFCURVE",
-"364 211 OFFCURVE",
-"398 376 CURVE SMOOTH",
-"418 478 OFFCURVE",
-"436 549 OFFCURVE",
-"450 590 CURVE SMOOTH",
-"475 664 OFFCURVE",
-"502 703 OFFCURVE",
-"532 703 CURVE SMOOTH",
-"540 703 OFFCURVE",
-"544 706 OFFCURVE",
-"545 715 CURVE SMOOTH",
-"545 717 OFFCURVE",
-"544 719 OFFCURVE",
-"544 721 CURVE SMOOTH",
-"544 731 OFFCURVE",
-"536 736 OFFCURVE",
-"523 736 CURVE SMOOTH",
-"492 736 OFFCURVE",
-"462 708 OFFCURVE",
-"437 655 CURVE",
-"424 649 OFFCURVE",
-"406 646 OFFCURVE",
-"382 646 CURVE SMOOTH",
-"326 646 OFFCURVE",
-"275 633 OFFCURVE",
-"231 609 CURVE SMOOTH",
-"178 579 OFFCURVE",
-"142 534 OFFCURVE",
-"121 474 CURVE SMOOTH",
-"111 446 OFFCURVE",
-"107 418 OFFCURVE",
-"107 389 CURVE SMOOTH",
-"107 330 OFFCURVE",
-"123 287 OFFCURVE",
-"156 256 CURVE SMOOTH",
-"179 233 OFFCURVE",
-"207 221 OFFCURVE",
-"238 217 CURVE",
-"212 103 OFFCURVE",
-"189 20 OFFCURVE",
-"168 -31 CURVE SMOOTH",
-"128 -124 OFFCURVE",
-"81 -170 OFFCURVE",
-"26 -170 CURVE SMOOTH",
-"15 -170 OFFCURVE",
-"10 -173 OFFCURVE",
-"10 -179 CURVE SMOOTH",
-"10 -180 LINE SMOOTH",
-"10 -189 OFFCURVE",
-"19 -193 OFFCURVE",
-"37 -193 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"190 -69 OFFCURVE",
-"221 11 OFFCURVE",
-"251 122 CURVE",
-"317 406 LINE SMOOTH",
-"343 507 OFFCURVE",
-"370 574 OFFCURVE",
-"398 607 CURVE",
-"419 609 LINE",
-"408 576 OFFCURVE",
-"397 537 OFFCURVE",
-"387 491 CURVE SMOOTH",
-"380 466 OFFCURVE",
-"372 425 OFFCURVE",
-"362 366 CURVE SMOOTH",
-"343 275 OFFCURVE",
-"332 215 OFFCURVE",
-"325 183 CURVE SMOOTH",
-"282 -10 OFFCURVE",
-"224 -111 OFFCURVE",
-"156 -120 CURVE"
-);
-}
-);
-width = 465;
-}
-);
-note = paragraph;
-unicode = 00B6;
-},
-{
-glyphname = section;
-lastChange = "2022-02-07 18:28:46 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"231 -174 OFFCURVE",
-"280 -162 OFFCURVE",
-"325 -140 CURVE SMOOTH",
-"375 -114 OFFCURVE",
-"409 -79 OFFCURVE",
-"428 -35 CURVE",
-"505 5 OFFCURVE",
-"543 63 OFFCURVE",
-"543 140 CURVE SMOOTH",
-"543 189 OFFCURVE",
-"525 230 OFFCURVE",
-"489 263 CURVE",
-"388 337 LINE SMOOTH",
-"352 365 OFFCURVE",
-"335 397 OFFCURVE",
-"335 433 CURVE SMOOTH",
-"335 469 OFFCURVE",
-"349 500 OFFCURVE",
-"378 522 CURVE SMOOTH",
-"404 542 OFFCURVE",
-"436 553 OFFCURVE",
-"474 553 CURVE SMOOTH",
-"534 553 OFFCURVE",
-"564 535 OFFCURVE",
-"564 497 CURVE SMOOTH",
-"564 468 OFFCURVE",
-"540 447 OFFCURVE",
-"509 447 CURVE SMOOTH",
-"500 447 OFFCURVE",
-"495 445 OFFCURVE",
-"495 442 CURVE SMOOTH",
-"495 439 OFFCURVE",
-"500 438 OFFCURVE",
-"508 438 CURVE SMOOTH",
-"566 438 OFFCURVE",
-"595 456 OFFCURVE",
-"595 492 CURVE SMOOTH",
-"595 516 OFFCURVE",
-"581 536 OFFCURVE",
-"550 548 CURVE SMOOTH",
-"527 559 OFFCURVE",
-"502 564 OFFCURVE",
-"473 564 CURVE SMOOTH",
-"435 564 OFFCURVE",
-"399 554 OFFCURVE",
-"366 535 CURVE SMOOTH",
-"328 512 OFFCURVE",
-"306 484 OFFCURVE",
-"300 449 CURVE",
-"231 423 OFFCURVE",
-"197 382 OFFCURVE",
-"197 323 CURVE SMOOTH",
-"197 286 OFFCURVE",
-"215 253 OFFCURVE",
-"250 222 CURVE",
-"346 149 LINE",
-"381 117 OFFCURVE",
-"398 78 OFFCURVE",
-"398 34 CURVE SMOOTH",
-"398 -43 OFFCURVE",
-"360 -99 OFFCURVE",
-"285 -134 CURVE SMOOTH",
-"248 -151 OFFCURVE",
-"213 -160 OFFCURVE",
-"180 -160 CURVE SMOOTH",
-"134 -160 OFFCURVE",
-"97 -144 OFFCURVE",
-"67 -112 CURVE SMOOTH",
-"38 -80 OFFCURVE",
-"23 -41 OFFCURVE",
-"23 5 CURVE SMOOTH",
-"23 91 OFFCURVE",
-"82 149 OFFCURVE",
-"169 149 CURVE SMOOTH",
-"184 149 OFFCURVE",
-"192 150 OFFCURVE",
-"192 151 CURVE SMOOTH",
-"192 156 OFFCURVE",
-"180 158 OFFCURVE",
-"155 158 CURVE SMOOTH",
-"107 158 OFFCURVE",
-"68 141 OFFCURVE",
-"37 105 CURVE SMOOTH",
-"6 70 OFFCURVE",
-"-10 28 OFFCURVE",
-"-10 -20 CURVE SMOOTH",
-"-10 -70 OFFCURVE",
-"10 -109 OFFCURVE",
-"49 -137 CURVE SMOOTH",
-"83 -161 OFFCURVE",
-"127 -174 OFFCURVE",
-"180 -174 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"441 8 OFFCURVE",
-"443 22 OFFCURVE",
-"443 38 CURVE SMOOTH",
-"443 88 OFFCURVE",
-"425 129 OFFCURVE",
-"389 162 CURVE",
-"289 234 LINE SMOOTH",
-"253 262 OFFCURVE",
-"234 295 OFFCURVE",
-"234 331 CURVE SMOOTH",
-"234 377 OFFCURVE",
-"256 412 OFFCURVE",
-"298 434 CURVE",
-"296 393 OFFCURVE",
-"312 357 OFFCURVE",
-"346 327 CURVE",
-"444 252 LINE",
-"480 220 OFFCURVE",
-"499 181 OFFCURVE",
-"499 137 CURVE SMOOTH",
-"499 74 OFFCURVE",
-"478 26 OFFCURVE",
-"438 -7 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"231 -174 OFFCURVE",
-"280 -162 OFFCURVE",
-"325 -140 CURVE SMOOTH",
-"375 -114 OFFCURVE",
-"409 -79 OFFCURVE",
-"428 -35 CURVE",
-"505 5 OFFCURVE",
-"543 63 OFFCURVE",
-"543 140 CURVE SMOOTH",
-"543 189 OFFCURVE",
-"525 230 OFFCURVE",
-"489 263 CURVE",
-"388 337 LINE SMOOTH",
-"352 365 OFFCURVE",
-"335 397 OFFCURVE",
-"335 433 CURVE SMOOTH",
-"335 469 OFFCURVE",
-"349 500 OFFCURVE",
-"378 522 CURVE SMOOTH",
-"404 542 OFFCURVE",
-"436 553 OFFCURVE",
-"474 553 CURVE SMOOTH",
-"534 553 OFFCURVE",
-"564 535 OFFCURVE",
-"564 497 CURVE SMOOTH",
-"564 468 OFFCURVE",
-"540 447 OFFCURVE",
-"509 447 CURVE SMOOTH",
-"500 447 OFFCURVE",
-"495 445 OFFCURVE",
-"495 442 CURVE SMOOTH",
-"495 439 OFFCURVE",
-"500 438 OFFCURVE",
-"508 438 CURVE SMOOTH",
-"566 438 OFFCURVE",
-"595 456 OFFCURVE",
-"595 492 CURVE SMOOTH",
-"595 516 OFFCURVE",
-"581 536 OFFCURVE",
-"550 548 CURVE SMOOTH",
-"527 559 OFFCURVE",
-"502 564 OFFCURVE",
-"473 564 CURVE SMOOTH",
-"435 564 OFFCURVE",
-"399 554 OFFCURVE",
-"366 535 CURVE SMOOTH",
-"328 512 OFFCURVE",
-"306 484 OFFCURVE",
-"300 449 CURVE",
-"231 423 OFFCURVE",
-"197 382 OFFCURVE",
-"197 323 CURVE SMOOTH",
-"197 286 OFFCURVE",
-"215 253 OFFCURVE",
-"250 222 CURVE",
-"346 149 LINE",
-"381 117 OFFCURVE",
-"398 78 OFFCURVE",
-"398 34 CURVE SMOOTH",
-"398 -43 OFFCURVE",
-"360 -99 OFFCURVE",
-"285 -134 CURVE SMOOTH",
-"248 -151 OFFCURVE",
-"213 -160 OFFCURVE",
-"180 -160 CURVE SMOOTH",
-"134 -160 OFFCURVE",
-"97 -144 OFFCURVE",
-"67 -112 CURVE SMOOTH",
-"38 -80 OFFCURVE",
-"23 -41 OFFCURVE",
-"23 5 CURVE SMOOTH",
-"23 91 OFFCURVE",
-"82 149 OFFCURVE",
-"169 149 CURVE SMOOTH",
-"184 149 OFFCURVE",
-"192 150 OFFCURVE",
-"192 151 CURVE SMOOTH",
-"192 156 OFFCURVE",
-"180 158 OFFCURVE",
-"155 158 CURVE SMOOTH",
-"107 158 OFFCURVE",
-"68 141 OFFCURVE",
-"37 105 CURVE SMOOTH",
-"6 70 OFFCURVE",
-"-10 28 OFFCURVE",
-"-10 -20 CURVE SMOOTH",
-"-10 -70 OFFCURVE",
-"10 -109 OFFCURVE",
-"49 -137 CURVE SMOOTH",
-"83 -161 OFFCURVE",
-"127 -174 OFFCURVE",
-"180 -174 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"441 8 OFFCURVE",
-"443 22 OFFCURVE",
-"443 38 CURVE SMOOTH",
-"443 88 OFFCURVE",
-"425 129 OFFCURVE",
-"389 162 CURVE",
-"289 234 LINE SMOOTH",
-"253 262 OFFCURVE",
-"234 295 OFFCURVE",
-"234 331 CURVE SMOOTH",
-"234 377 OFFCURVE",
-"256 412 OFFCURVE",
-"298 434 CURVE",
-"296 393 OFFCURVE",
-"312 357 OFFCURVE",
-"346 327 CURVE",
-"444 252 LINE",
-"480 220 OFFCURVE",
-"499 181 OFFCURVE",
-"499 137 CURVE SMOOTH",
-"499 74 OFFCURVE",
-"478 26 OFFCURVE",
-"438 -7 CURVE"
-);
-}
-);
-width = 591;
-}
-);
-note = section;
-unicode = 00A7;
-},
-{
-glyphname = copyright;
-lastChange = "2022-02-14 10:09:05 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"435 28 OFFCURVE",
-"623 198 OFFCURVE",
-"609 355 CURVE SMOOTH",
-"601 448 OFFCURVE",
-"521 509 OFFCURVE",
-"429 509 CURVE SMOOTH",
-"274 509 OFFCURVE",
-"84 339 OFFCURVE",
-"98 181 CURVE SMOOTH",
-"106 89 OFFCURVE",
-"191 28 OFFCURVE",
-"283 28 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"218 49 OFFCURVE",
-"140 99 OFFCURVE",
-"133 180 CURVE SMOOTH",
-"120 329 OFFCURVE",
-"273 490 OFFCURVE",
-"421 490 CURVE SMOOTH",
-"504 490 OFFCURVE",
-"566 430 OFFCURVE",
-"573 347 CURVE SMOOTH",
-"586 206 OFFCURVE",
-"432 49 OFFCURVE",
-"295 49 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"344 142 OFFCURVE",
-"377 154 OFFCURVE",
-"414 177 CURVE SMOOTH",
-"448 197 OFFCURVE",
-"474 221 OFFCURVE",
-"492 247 CURVE SMOOTH",
-"495 252 OFFCURVE",
-"497 255 OFFCURVE",
-"497 258 CURVE SMOOTH",
-"497 261 OFFCURVE",
-"496 261 OFFCURVE",
-"493 261 CURVE SMOOTH",
-"488 261 OFFCURVE",
-"482 258 OFFCURVE",
-"476 250 CURVE SMOOTH",
-"433 196 OFFCURVE",
-"386 169 OFFCURVE",
-"333 169 CURVE SMOOTH",
-"292 169 OFFCURVE",
-"271 193 OFFCURVE",
-"271 243 CURVE SMOOTH",
-"271 267 OFFCURVE",
-"278 293 OFFCURVE",
-"292 317 CURVE SMOOTH",
-"309 345 OFFCURVE",
-"327 359 OFFCURVE",
-"350 359 CURVE SMOOTH",
-"369 359 OFFCURVE",
-"379 351 OFFCURVE",
-"379 335 CURVE SMOOTH",
-"379 328 OFFCURVE",
-"374 313 OFFCURVE",
-"374 308 CURVE SMOOTH",
-"375 303 OFFCURVE",
-"376 301 OFFCURVE",
-"378 301 CURVE SMOOTH",
-"383 301 OFFCURVE",
-"389 310 OFFCURVE",
-"397 328 CURVE SMOOTH",
-"406 345 OFFCURVE",
-"411 357 OFFCURVE",
-"411 364 CURVE SMOOTH",
-"411 382 OFFCURVE",
-"399 391 OFFCURVE",
-"375 391 CURVE SMOOTH",
-"344 391 OFFCURVE",
-"312 373 OFFCURVE",
-"281 336 CURVE SMOOTH",
-"251 299 OFFCURVE",
-"235 263 OFFCURVE",
-"235 231 CURVE SMOOTH",
-"235 181 OFFCURVE",
-"265 142 OFFCURVE",
-"314 142 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"431 28 OFFCURVE",
-"610 186 OFFCURVE",
-"610 339 CURVE SMOOTH",
-"610 441 OFFCURVE",
-"526 509 OFFCURVE",
-"429 509 CURVE SMOOTH",
-"279 509 OFFCURVE",
-"97 350 OFFCURVE",
-"97 197 CURVE SMOOTH",
-"97 96 OFFCURVE",
-"186 28 OFFCURVE",
-"283 28 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"218 49 OFFCURVE",
-"140 99 OFFCURVE",
-"133 180 CURVE SMOOTH",
-"120 329 OFFCURVE",
-"273 490 OFFCURVE",
-"421 490 CURVE SMOOTH",
-"510 490 OFFCURVE",
-"574 422 OFFCURVE",
-"574 331 CURVE SMOOTH",
-"574 194 OFFCURVE",
-"427 49 OFFCURVE",
-"295 49 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"344 142 OFFCURVE",
-"377 154 OFFCURVE",
-"414 177 CURVE SMOOTH",
-"448 197 OFFCURVE",
-"474 221 OFFCURVE",
-"492 247 CURVE SMOOTH",
-"495 252 OFFCURVE",
-"497 255 OFFCURVE",
-"497 258 CURVE SMOOTH",
-"497 261 OFFCURVE",
-"496 261 OFFCURVE",
-"493 261 CURVE SMOOTH",
-"488 261 OFFCURVE",
-"482 258 OFFCURVE",
-"476 250 CURVE SMOOTH",
-"433 196 OFFCURVE",
-"386 169 OFFCURVE",
-"333 169 CURVE SMOOTH",
-"292 169 OFFCURVE",
-"271 193 OFFCURVE",
-"271 243 CURVE SMOOTH",
-"271 267 OFFCURVE",
-"278 293 OFFCURVE",
-"292 317 CURVE SMOOTH",
-"309 345 OFFCURVE",
-"327 359 OFFCURVE",
-"350 359 CURVE SMOOTH",
-"369 359 OFFCURVE",
-"379 351 OFFCURVE",
-"379 335 CURVE SMOOTH",
-"379 328 OFFCURVE",
-"374 313 OFFCURVE",
-"374 308 CURVE SMOOTH",
-"375 303 OFFCURVE",
-"376 301 OFFCURVE",
-"378 301 CURVE SMOOTH",
-"383 301 OFFCURVE",
-"389 310 OFFCURVE",
-"397 328 CURVE SMOOTH",
-"406 345 OFFCURVE",
-"411 357 OFFCURVE",
-"411 364 CURVE SMOOTH",
-"411 382 OFFCURVE",
-"399 391 OFFCURVE",
-"375 391 CURVE SMOOTH",
-"344 391 OFFCURVE",
-"312 373 OFFCURVE",
-"281 336 CURVE SMOOTH",
-"251 299 OFFCURVE",
-"235 263 OFFCURVE",
-"235 231 CURVE SMOOTH",
-"235 181 OFFCURVE",
-"265 142 OFFCURVE",
-"314 142 CURVE SMOOTH"
-);
-}
-);
-width = 623;
-}
-);
-note = copyright;
-unicode = 00A9;
-},
-{
-glyphname = registered;
-lastChange = "2022-02-14 10:09:09 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"571 448 OFFCURVE",
-"491 509 OFFCURVE",
-"399 509 CURVE SMOOTH",
-"244 509 OFFCURVE",
-"54 339 OFFCURVE",
-"68 181 CURVE SMOOTH",
-"76 89 OFFCURVE",
-"161 28 OFFCURVE",
-"253 28 CURVE SMOOTH",
-"405 28 OFFCURVE",
-"593 198 OFFCURVE",
-"579 355 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"420 118 LINE SMOOTH",
-"379 118 OFFCURVE",
-"342 166 OFFCURVE",
-"317 255 CURVE",
-"356 256 OFFCURVE",
-"393 262 OFFCURVE",
-"428 277 CURVE SMOOTH",
-"474 296 OFFCURVE",
-"497 322 OFFCURVE",
-"497 354 CURVE SMOOTH",
-"497 381 OFFCURVE",
-"481 401 OFFCURVE",
-"448 414 CURVE SMOOTH",
-"425 423 OFFCURVE",
-"398 428 OFFCURVE",
-"366 428 CURVE SMOOTH",
-"314 428 OFFCURVE",
-"259 417 OFFCURVE",
-"201 394 CURVE SMOOTH",
-"195 391 OFFCURVE",
-"189 389 OFFCURVE",
-"185 388 CURVE",
-"241 449 OFFCURVE",
-"317 490 OFFCURVE",
-"391 490 CURVE SMOOTH",
-"474 490 OFFCURVE",
-"536 430 OFFCURVE",
-"543 347 CURVE SMOOTH",
-"551 264 OFFCURVE",
-"501 177 OFFCURVE",
-"432 118 CURVE"
-);
-},
-{
-closed = 1;
-nodes = (
-"169 78 OFFCURVE",
-"169 81 OFFCURVE",
-"170 85 CURVE SMOOTH",
-"175 118 OFFCURVE",
-"198 166 OFFCURVE",
-"240 227 CURVE SMOOTH",
-"261 260 OFFCURVE",
-"294 302 OFFCURVE",
-"338 358 CURVE SMOOTH",
-"359 384 OFFCURVE",
-"368 398 OFFCURVE",
-"369 400 CURVE",
-"348 411 LINE",
-"316 379 OFFCURVE",
-"278 331 OFFCURVE",
-"234 265 CURVE SMOOTH",
-"182 190 OFFCURVE",
-"156 138 OFFCURVE",
-"156 109 CURVE SMOOTH",
-"156 98 OFFCURVE",
-"157 89 OFFCURVE",
-"159 83 CURVE",
-"128 105 OFFCURVE",
-"107 139 OFFCURVE",
-"103 180 CURVE SMOOTH",
-"98 241 OFFCURVE",
-"120 304 OFFCURVE",
-"161 358 CURVE",
-"164 360 OFFCURVE",
-"168 361 OFFCURVE",
-"172 363 CURVE SMOOTH",
-"197 376 OFFCURVE",
-"228 387 OFFCURVE",
-"266 398 CURVE SMOOTH",
-"307 411 OFFCURVE",
-"339 417 OFFCURVE",
-"362 417 CURVE SMOOTH",
-"436 417 OFFCURVE",
-"473 398 OFFCURVE",
-"473 361 CURVE SMOOTH",
-"473 301 OFFCURVE",
-"363 266 OFFCURVE",
-"290 266 CURVE SMOOTH",
-"281 266 OFFCURVE",
-"283 261 OFFCURVE",
-"287 258 CURVE",
-"296 227 OFFCURVE",
-"310 197 OFFCURVE",
-"328 169 CURVE SMOOTH",
-"352 133 OFFCURVE",
-"375 111 OFFCURVE",
-"400 105 CURVE SMOOTH",
-"404 104 OFFCURVE",
-"409 103 OFFCURVE",
-"414 103 CURVE",
-"368 70 OFFCURVE",
-"316 49 OFFCURVE",
-"265 49 CURVE SMOOTH",
-"231 49 OFFCURVE",
-"197 59 OFFCURVE",
-"168 76 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"401 28 OFFCURVE",
-"580 186 OFFCURVE",
-"580 339 CURVE SMOOTH",
-"580 441 OFFCURVE",
-"496 509 OFFCURVE",
-"399 509 CURVE SMOOTH",
-"249 509 OFFCURVE",
-"67 350 OFFCURVE",
-"67 197 CURVE SMOOTH",
-"67 96 OFFCURVE",
-"156 28 OFFCURVE",
-"253 28 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"231 49 OFFCURVE",
-"197 59 OFFCURVE",
-"168 76 CURVE",
-"169 78 OFFCURVE",
-"169 81 OFFCURVE",
-"170 85 CURVE SMOOTH",
-"175 118 OFFCURVE",
-"198 166 OFFCURVE",
-"240 227 CURVE SMOOTH",
-"261 260 OFFCURVE",
-"294 302 OFFCURVE",
-"338 358 CURVE SMOOTH",
-"359 384 OFFCURVE",
-"368 398 OFFCURVE",
-"369 400 CURVE",
-"348 411 LINE",
-"316 379 OFFCURVE",
-"278 331 OFFCURVE",
-"234 265 CURVE SMOOTH",
-"182 190 OFFCURVE",
-"156 138 OFFCURVE",
-"156 109 CURVE SMOOTH",
-"156 98 OFFCURVE",
-"157 89 OFFCURVE",
-"159 83 CURVE",
-"124 108 OFFCURVE",
-"102 147 OFFCURVE",
-"102 196 CURVE SMOOTH",
-"102 253 OFFCURVE",
-"124 309 OFFCURVE",
-"161 358 CURVE",
-"164 360 OFFCURVE",
-"168 361 OFFCURVE",
-"172 363 CURVE SMOOTH",
-"197 376 OFFCURVE",
-"228 387 OFFCURVE",
-"266 398 CURVE SMOOTH",
-"307 411 OFFCURVE",
-"339 417 OFFCURVE",
-"362 417 CURVE SMOOTH",
-"436 417 OFFCURVE",
-"473 398 OFFCURVE",
-"473 361 CURVE SMOOTH",
-"473 301 OFFCURVE",
-"363 266 OFFCURVE",
-"290 266 CURVE SMOOTH",
-"281 266 OFFCURVE",
-"283 261 OFFCURVE",
-"287 258 CURVE",
-"296 227 OFFCURVE",
-"310 197 OFFCURVE",
-"328 169 CURVE SMOOTH",
-"352 133 OFFCURVE",
-"375 111 OFFCURVE",
-"400 105 CURVE SMOOTH",
-"404 104 OFFCURVE",
-"409 103 OFFCURVE",
-"414 103 CURVE",
-"368 70 OFFCURVE",
-"316 49 OFFCURVE",
-"265 49 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"379 118 OFFCURVE",
-"342 166 OFFCURVE",
-"317 255 CURVE",
-"356 256 OFFCURVE",
-"393 262 OFFCURVE",
-"428 277 CURVE SMOOTH",
-"474 296 OFFCURVE",
-"497 322 OFFCURVE",
-"497 354 CURVE SMOOTH",
-"497 381 OFFCURVE",
-"481 401 OFFCURVE",
-"448 414 CURVE SMOOTH",
-"425 423 OFFCURVE",
-"398 428 OFFCURVE",
-"366 428 CURVE SMOOTH",
-"314 428 OFFCURVE",
-"259 417 OFFCURVE",
-"201 394 CURVE SMOOTH",
-"195 391 OFFCURVE",
-"189 389 OFFCURVE",
-"185 388 CURVE",
-"241 449 OFFCURVE",
-"317 490 OFFCURVE",
-"391 490 CURVE SMOOTH",
-"480 490 OFFCURVE",
-"544 422 OFFCURVE",
-"544 330 CURVE SMOOTH",
-"544 253 OFFCURVE",
-"496 173 OFFCURVE",
-"432 118 CURVE",
-"420 118 LINE SMOOTH"
-);
-}
-);
-width = 623;
-}
-);
-note = registered;
-unicode = 00AE;
-},
-{
-glyphname = trademark;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"369 320 OFFCURVE",
-"378 325 OFFCURVE",
-"385 336 CURVE SMOOTH",
-"395 351 OFFCURVE",
-"404 380 OFFCURVE",
-"415 420 CURVE SMOOTH",
-"427 464 OFFCURVE",
-"437 495 OFFCURVE",
-"443 509 CURVE",
-"468 422 OFFCURVE",
-"496 378 OFFCURVE",
-"530 378 CURVE SMOOTH",
-"562 378 OFFCURVE",
-"611 422 OFFCURVE",
-"680 509 CURVE",
-"665 438 OFFCURVE",
-"655 384 OFFCURVE",
-"648 348 CURVE SMOOTH",
-"647 344 OFFCURVE",
-"647 341 OFFCURVE",
-"647 341 CURVE SMOOTH",
-"647 335 OFFCURVE",
-"651 332 OFFCURVE",
-"658 332 CURVE SMOOTH",
-"675 332 OFFCURVE",
-"685 338 OFFCURVE",
-"692 348 CURVE",
-"699 407 OFFCURVE",
-"704 462 OFFCURVE",
-"706 513 CURVE",
-"707 519 OFFCURVE",
-"709 531 OFFCURVE",
-"714 549 CURVE SMOOTH",
-"717 565 OFFCURVE",
-"719 576 OFFCURVE",
-"719 582 CURVE SMOOTH",
-"719 600 OFFCURVE",
-"715 609 OFFCURVE",
-"707 609 CURVE SMOOTH",
-"706 609 OFFCURVE",
-"682 574 OFFCURVE",
-"637 503 CURVE SMOOTH",
-"592 433 OFFCURVE",
-"560 398 OFFCURVE",
-"540 398 CURVE SMOOTH",
-"518 398 OFFCURVE",
-"501 426 OFFCURVE",
-"488 482 CURVE",
-"482 520 OFFCURVE",
-"477 558 OFFCURVE",
-"470 596 CURVE SMOOTH",
-"466 611 OFFCURVE",
-"462 618 OFFCURVE",
-"457 618 CURVE SMOOTH",
-"444 618 OFFCURVE",
-"437 606 OFFCURVE",
-"434 583 CURVE SMOOTH",
-"432 568 OFFCURVE",
-"430 552 OFFCURVE",
-"429 536 CURVE",
-"426 527 OFFCURVE",
-"411 489 OFFCURVE",
-"385 423 CURVE SMOOTH",
-"361 362 OFFCURVE",
-"348 330 OFFCURVE",
-"348 327 CURVE SMOOTH",
-"348 322 OFFCURVE",
-"352 320 OFFCURVE",
-"359 320 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 314 OFFCURVE",
-"186 317 OFFCURVE",
-"190 323 CURVE",
-"201 349 OFFCURVE",
-"210 372 OFFCURVE",
-"215 388 CURVE SMOOTH",
-"226 421 OFFCURVE",
-"236 454 OFFCURVE",
-"245 486 CURVE SMOOTH",
-"259 528 OFFCURVE",
-"272 559 OFFCURVE",
-"282 580 CURVE SMOOTH",
-"287 588 OFFCURVE",
-"314 595 OFFCURVE",
-"361 600 CURVE SMOOTH",
-"406 605 OFFCURVE",
-"429 612 OFFCURVE",
-"429 620 CURVE SMOOTH",
-"429 624 OFFCURVE",
-"422 627 OFFCURVE",
-"407 627 CURVE SMOOTH",
-"371 627 OFFCURVE",
-"321 624 OFFCURVE",
-"258 620 CURVE SMOOTH",
-"175 614 OFFCURVE",
-"131 607 OFFCURVE",
-"126 598 CURVE",
-"129 589 OFFCURVE",
-"137 585 OFFCURVE",
-"151 585 CURVE SMOOTH",
-"166 585 OFFCURVE",
-"205 590 OFFCURVE",
-"221 590 CURVE SMOOTH",
-"240 590 OFFCURVE",
-"248 587 OFFCURVE",
-"248 582 CURVE SMOOTH",
-"248 577 OFFCURVE",
-"244 563 OFFCURVE",
-"237 541 CURVE",
-"220 503 OFFCURVE",
-"204 466 OFFCURVE",
-"189 429 CURVE SMOOTH",
-"164 370 OFFCURVE",
-"152 336 OFFCURVE",
-"152 327 CURVE SMOOTH",
-"152 318 OFFCURVE",
-"158 314 OFFCURVE",
-"169 314 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"369 320 OFFCURVE",
-"378 325 OFFCURVE",
-"385 336 CURVE SMOOTH",
-"395 351 OFFCURVE",
-"404 380 OFFCURVE",
-"415 420 CURVE SMOOTH",
-"427 464 OFFCURVE",
-"437 495 OFFCURVE",
-"443 509 CURVE",
-"468 422 OFFCURVE",
-"496 378 OFFCURVE",
-"530 378 CURVE SMOOTH",
-"562 378 OFFCURVE",
-"611 422 OFFCURVE",
-"680 509 CURVE",
-"665 438 OFFCURVE",
-"655 384 OFFCURVE",
-"648 348 CURVE SMOOTH",
-"647 344 OFFCURVE",
-"647 341 OFFCURVE",
-"647 341 CURVE",
-"647 335 OFFCURVE",
-"651 332 OFFCURVE",
-"658 332 CURVE SMOOTH",
-"675 332 OFFCURVE",
-"685 338 OFFCURVE",
-"692 348 CURVE",
-"699 407 OFFCURVE",
-"704 462 OFFCURVE",
-"706 513 CURVE",
-"707 519 OFFCURVE",
-"709 531 OFFCURVE",
-"714 549 CURVE SMOOTH",
-"717 565 OFFCURVE",
-"719 576 OFFCURVE",
-"719 582 CURVE SMOOTH",
-"719 600 OFFCURVE",
-"715 609 OFFCURVE",
-"707 609 CURVE SMOOTH",
-"706 609 OFFCURVE",
-"682 574 OFFCURVE",
-"637 503 CURVE SMOOTH",
-"592 433 OFFCURVE",
-"560 398 OFFCURVE",
-"540 398 CURVE SMOOTH",
-"518 398 OFFCURVE",
-"501 426 OFFCURVE",
-"488 482 CURVE",
-"482 520 OFFCURVE",
-"477 558 OFFCURVE",
-"470 596 CURVE SMOOTH",
-"466 611 OFFCURVE",
-"462 618 OFFCURVE",
-"457 618 CURVE SMOOTH",
-"444 618 OFFCURVE",
-"437 606 OFFCURVE",
-"434 583 CURVE SMOOTH",
-"432 568 OFFCURVE",
-"430 552 OFFCURVE",
-"429 536 CURVE",
-"426 527 OFFCURVE",
-"411 489 OFFCURVE",
-"385 423 CURVE SMOOTH",
-"361 362 OFFCURVE",
-"348 330 OFFCURVE",
-"348 327 CURVE SMOOTH",
-"348 322 OFFCURVE",
-"352 320 OFFCURVE",
-"359 320 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"179 314 OFFCURVE",
-"186 317 OFFCURVE",
-"190 323 CURVE",
-"201 349 OFFCURVE",
-"210 372 OFFCURVE",
-"215 388 CURVE SMOOTH",
-"226 421 OFFCURVE",
-"236 454 OFFCURVE",
-"245 486 CURVE SMOOTH",
-"259 528 OFFCURVE",
-"272 559 OFFCURVE",
-"282 580 CURVE SMOOTH",
-"287 588 OFFCURVE",
-"314 595 OFFCURVE",
-"361 600 CURVE SMOOTH",
-"406 605 OFFCURVE",
-"429 612 OFFCURVE",
-"429 620 CURVE SMOOTH",
-"429 624 OFFCURVE",
-"422 627 OFFCURVE",
-"407 627 CURVE SMOOTH",
-"371 627 OFFCURVE",
-"321 624 OFFCURVE",
-"258 620 CURVE SMOOTH",
-"175 614 OFFCURVE",
-"131 607 OFFCURVE",
-"126 598 CURVE",
-"129 589 OFFCURVE",
-"137 585 OFFCURVE",
-"151 585 CURVE SMOOTH",
-"166 585 OFFCURVE",
-"205 590 OFFCURVE",
-"221 590 CURVE SMOOTH",
-"240 590 OFFCURVE",
-"248 587 OFFCURVE",
-"248 582 CURVE SMOOTH",
-"248 577 OFFCURVE",
-"244 563 OFFCURVE",
-"237 541 CURVE",
-"220 503 OFFCURVE",
-"204 466 OFFCURVE",
-"189 429 CURVE SMOOTH",
-"164 370 OFFCURVE",
-"152 336 OFFCURVE",
-"152 327 CURVE SMOOTH",
-"152 318 OFFCURVE",
-"158 314 OFFCURVE",
-"169 314 CURVE SMOOTH"
-);
-}
-);
-width = 721;
-}
-);
-note = trademark;
-unicode = 2122;
-},
-{
-glyphname = degree;
-lastChange = "2022-02-14 20:35:57 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"223 349 OFFCURVE",
-"263 389 OFFCURVE",
-"263 437 CURVE SMOOTH",
-"263 485 OFFCURVE",
-"223 526 OFFCURVE",
-"175 526 CURVE SMOOTH",
-"127 526 OFFCURVE",
-"87 485 OFFCURVE",
-"87 437 CURVE SMOOTH",
-"87 389 OFFCURVE",
-"127 349 OFFCURVE",
-"175 349 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"147 385 OFFCURVE",
-"123 410 OFFCURVE",
-"123 437 CURVE SMOOTH",
-"123 465 OFFCURVE",
-"147 490 OFFCURVE",
-"175 490 CURVE SMOOTH",
-"203 490 OFFCURVE",
-"227 465 OFFCURVE",
-"227 437 CURVE SMOOTH",
-"227 410 OFFCURVE",
-"203 385 OFFCURVE",
-"175 385 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"223 349 OFFCURVE",
-"263 389 OFFCURVE",
-"263 437 CURVE SMOOTH",
-"263 485 OFFCURVE",
-"223 526 OFFCURVE",
-"175 526 CURVE SMOOTH",
-"127 526 OFFCURVE",
-"87 485 OFFCURVE",
-"87 437 CURVE SMOOTH",
-"87 389 OFFCURVE",
-"127 349 OFFCURVE",
-"175 349 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"147 385 OFFCURVE",
-"123 410 OFFCURVE",
-"123 437 CURVE SMOOTH",
-"123 465 OFFCURVE",
-"147 490 OFFCURVE",
-"175 490 CURVE SMOOTH",
-"203 490 OFFCURVE",
-"227 465 OFFCURVE",
-"227 437 CURVE SMOOTH",
-"227 410 OFFCURVE",
-"203 385 OFFCURVE",
-"175 385 CURVE SMOOTH"
-);
-}
-);
-width = 285;
-}
-);
-note = degree;
-unicode = 00B0;
-},
-{
-glyphname = minute;
-lastChange = "2022-02-14 13:13:31 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"188 712 OFFCURVE",
-"220 785 OFFCURVE",
-"220 799 CURVE SMOOTH",
-"220 813 OFFCURVE",
-"213 820 OFFCURVE",
-"204 820 CURVE SMOOTH",
-"191 820 OFFCURVE",
-"189 810 OFFCURVE",
-"188 802 CURVE SMOOTH",
-"183 777 OFFCURVE",
-"167 707 OFFCURVE",
-"152 676 CURVE SMOOTH",
-"151 675 OFFCURVE",
-"166 674 OFFCURVE",
-"168 676 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"164 675 OFFCURVE",
-"167 675 OFFCURVE",
-"168 676 CURVE",
-"188 712 OFFCURVE",
-"220 785 OFFCURVE",
-"220 799 CURVE SMOOTH",
-"220 813 OFFCURVE",
-"213 820 OFFCURVE",
-"204 820 CURVE SMOOTH",
-"191 820 OFFCURVE",
-"189 810 OFFCURVE",
-"188 802 CURVE SMOOTH",
-"183 777 OFFCURVE",
-"167 707 OFFCURVE",
-"152 676 CURVE",
-"151 675 OFFCURVE",
-"156 675 OFFCURVE",
-"161 675 CURVE SMOOTH"
-);
-}
-);
-width = 158;
-}
-);
-leftKerningGroup = quotes;
-rightKerningGroup = quotes;
-unicode = 2032;
-},
-{
-glyphname = second;
-lastChange = "2022-02-14 13:13:31 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"188 712 OFFCURVE",
-"220 785 OFFCURVE",
-"220 799 CURVE SMOOTH",
-"220 813 OFFCURVE",
-"213 820 OFFCURVE",
-"204 820 CURVE SMOOTH",
-"191 820 OFFCURVE",
-"189 810 OFFCURVE",
-"188 802 CURVE SMOOTH",
-"183 777 OFFCURVE",
-"167 707 OFFCURVE",
-"152 676 CURVE SMOOTH",
-"151 675 OFFCURVE",
-"166 674 OFFCURVE",
-"168 676 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"286 712 OFFCURVE",
-"317 785 OFFCURVE",
-"317 799 CURVE SMOOTH",
-"317 813 OFFCURVE",
-"310 820 OFFCURVE",
-"301 820 CURVE SMOOTH",
-"289 820 OFFCURVE",
-"287 810 OFFCURVE",
-"286 802 CURVE SMOOTH",
-"281 777 OFFCURVE",
-"264 707 OFFCURVE",
-"250 676 CURVE SMOOTH",
-"249 675 OFFCURVE",
-"263 674 OFFCURVE",
-"265 676 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"164 675 OFFCURVE",
-"167 675 OFFCURVE",
-"168 676 CURVE",
-"188 712 OFFCURVE",
-"220 785 OFFCURVE",
-"220 799 CURVE SMOOTH",
-"220 813 OFFCURVE",
-"213 820 OFFCURVE",
-"204 820 CURVE SMOOTH",
-"191 820 OFFCURVE",
-"189 810 OFFCURVE",
-"188 802 CURVE SMOOTH",
-"183 777 OFFCURVE",
-"167 707 OFFCURVE",
-"152 676 CURVE",
-"151 675 OFFCURVE",
-"156 675 OFFCURVE",
-"161 675 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"261 675 OFFCURVE",
-"264 675 OFFCURVE",
-"265 676 CURVE",
-"286 712 OFFCURVE",
-"317 785 OFFCURVE",
-"317 799 CURVE SMOOTH",
-"317 813 OFFCURVE",
-"310 820 OFFCURVE",
-"301 820 CURVE SMOOTH",
-"289 820 OFFCURVE",
-"287 810 OFFCURVE",
-"286 802 CURVE SMOOTH",
-"281 777 OFFCURVE",
-"264 707 OFFCURVE",
-"250 676 CURVE",
-"249 675 OFFCURVE",
-"254 675 OFFCURVE",
-"259 675 CURVE SMOOTH"
-);
-}
-);
-width = 255;
-}
-);
-leftKerningGroup = quotes;
-rightKerningGroup = quotes;
-unicode = 2033;
-},
-{
-glyphname = bar;
-lastChange = "2022-02-14 10:09:45 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"96 -114 OFFCURVE",
-"106 -107 OFFCURVE",
-"115 -95 CURVE SMOOTH",
-"131 -71 OFFCURVE",
-"151 35 OFFCURVE",
-"174 224 CURVE SMOOTH",
-"195 397 OFFCURVE",
-"206 513 OFFCURVE",
-"206 572 CURVE SMOOTH",
-"206 575 OFFCURVE",
-"206 580 OFFCURVE",
-"207 586 CURVE",
-"207 602 LINE SMOOTH",
-"207 665 OFFCURVE",
-"192 698 OFFCURVE",
-"162 698 CURVE SMOOTH",
-"149 698 OFFCURVE",
-"143 694 OFFCURVE",
-"143 687 CURVE SMOOTH",
-"143 678 OFFCURVE",
-"145 667 OFFCURVE",
-"148 655 CURVE SMOOTH",
-"153 638 OFFCURVE",
-"155 627 OFFCURVE",
-"156 622 CURVE SMOOTH",
-"160 592 OFFCURVE",
-"162 548 OFFCURVE",
-"162 491 CURVE SMOOTH",
-"162 350 OFFCURVE",
-"150 209 OFFCURVE",
-"126 66 CURVE SMOOTH",
-"102 -50 OFFCURVE",
-"87 -106 OFFCURVE",
-"87 -113 CURVE SMOOTH",
-"87 -114 OFFCURVE",
-"87 -114 OFFCURVE",
-"88 -114 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"96 -114 OFFCURVE",
-"106 -107 OFFCURVE",
-"115 -95 CURVE SMOOTH",
-"131 -71 OFFCURVE",
-"151 35 OFFCURVE",
-"174 224 CURVE SMOOTH",
-"195 397 OFFCURVE",
-"206 513 OFFCURVE",
-"206 572 CURVE SMOOTH",
-"206 575 OFFCURVE",
-"206 580 OFFCURVE",
-"207 586 CURVE",
-"207 602 LINE SMOOTH",
-"207 665 OFFCURVE",
-"192 698 OFFCURVE",
-"162 698 CURVE SMOOTH",
-"149 698 OFFCURVE",
-"143 694 OFFCURVE",
-"143 687 CURVE SMOOTH",
-"143 678 OFFCURVE",
-"145 667 OFFCURVE",
-"148 655 CURVE SMOOTH",
-"153 638 OFFCURVE",
-"155 627 OFFCURVE",
-"156 622 CURVE SMOOTH",
-"160 592 OFFCURVE",
-"162 548 OFFCURVE",
-"162 491 CURVE SMOOTH",
-"162 350 OFFCURVE",
-"150 209 OFFCURVE",
-"126 66 CURVE SMOOTH",
-"102 -50 OFFCURVE",
-"87 -106 OFFCURVE",
-"87 -113 CURVE SMOOTH",
-"87 -114 OFFCURVE",
-"87 -114 OFFCURVE",
-"88 -114 CURVE SMOOTH"
-);
-}
-);
-width = 245;
-}
-);
-note = bar;
-unicode = 007C;
-},
-{
-glyphname = brokenbar;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"88 -114 OFFCURVE",
-"98 -107 OFFCURVE",
-"107 -95 CURVE SMOOTH",
-"123 -71 OFFCURVE",
-"143 35 OFFCURVE",
-"166 224 CURVE SMOOTH",
-"187 397 OFFCURVE",
-"198 513 OFFCURVE",
-"198 572 CURVE SMOOTH",
-"198 575 OFFCURVE",
-"198 580 OFFCURVE",
-"199 586 CURVE",
-"199 602 LINE SMOOTH",
-"199 665 OFFCURVE",
-"184 698 OFFCURVE",
-"154 698 CURVE SMOOTH",
-"141 698 OFFCURVE",
-"135 694 OFFCURVE",
-"135 687 CURVE SMOOTH",
-"135 678 OFFCURVE",
-"137 667 OFFCURVE",
-"140 655 CURVE SMOOTH",
-"145 638 OFFCURVE",
-"147 627 OFFCURVE",
-"148 622 CURVE SMOOTH",
-"152 592 OFFCURVE",
-"154 548 OFFCURVE",
-"154 491 CURVE SMOOTH",
-"154 350 OFFCURVE",
-"142 209 OFFCURVE",
-"118 66 CURVE SMOOTH",
-"94 -50 OFFCURVE",
-"79 -106 OFFCURVE",
-"79 -113 CURVE SMOOTH",
-"79 -114 OFFCURVE",
-"79 -114 OFFCURVE",
-"80 -114 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"98 -112 OFFCURVE",
-"107 -106 OFFCURVE",
-"113 -96 CURVE SMOOTH",
-"119 -86 OFFCURVE",
-"131 -32 OFFCURVE",
-"146 71 CURVE SMOOTH",
-"164 173 OFFCURVE",
-"172 234 OFFCURVE",
-"172 252 CURVE SMOOTH",
-"172 258 OFFCURVE",
-"168 260 OFFCURVE",
-"159 260 CURVE SMOOTH",
-"152 260 OFFCURVE",
-"146 258 OFFCURVE",
-"144 252 CURVE",
-"142 223 OFFCURVE",
-"140 197 OFFCURVE",
-"139 173 CURVE",
-"133 123 OFFCURVE",
-"125 75 OFFCURVE",
-"115 26 CURVE SMOOTH",
-"87 -112 LINE",
-"91 -115 LINE"
-);
-},
-{
-closed = 1;
-nodes = (
-"172 318 OFFCURVE",
-"178 320 OFFCURVE",
-"182 328 CURVE SMOOTH",
-"192 350 OFFCURVE",
-"198 436 OFFCURVE",
-"198 596 CURVE SMOOTH",
-"198 662 OFFCURVE",
-"183 696 OFFCURVE",
-"157 696 CURVE SMOOTH",
-"144 696 OFFCURVE",
-"140 692 OFFCURVE",
-"140 683 CURVE SMOOTH",
-"140 668 OFFCURVE",
-"148 635 OFFCURVE",
-"148 626 CURVE",
-"154 594 OFFCURVE",
-"157 547 OFFCURVE",
-"157 487 CURVE SMOOTH",
-"157 451 OFFCURVE",
-"150 362 OFFCURVE",
-"150 328 CURVE SMOOTH",
-"150 320 OFFCURVE",
-"154 318 OFFCURVE",
-"162 318 CURVE SMOOTH"
-);
-}
-);
-width = 236;
-}
-);
-leftMetricsKey = bar;
-note = brokenbar;
-rightMetricsKey = bar;
-unicode = 00A6;
-},
-{
-glyphname = dagger;
-lastChange = "2022-02-14 17:04:14 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"196 11 OFFCURVE",
-"197 12 OFFCURVE",
-"198 14 CURVE",
-"207 50 OFFCURVE",
-"212 79 OFFCURVE",
-"214 100 CURVE SMOOTH",
-"225 182 OFFCURVE",
-"236 280 OFFCURVE",
-"246 394 CURVE",
-"305 397 OFFCURVE",
-"357 398 OFFCURVE",
-"400 398 CURVE SMOOTH",
-"407 398 OFFCURVE",
-"411 400 OFFCURVE",
-"411 403 CURVE SMOOTH",
-"411 404 OFFCURVE",
-"409 405 OFFCURVE",
-"406 406 CURVE SMOOTH",
-"373 413 OFFCURVE",
-"320 417 OFFCURVE",
-"248 418 CURVE",
-"255 499 OFFCURVE",
-"258 557 OFFCURVE",
-"258 594 CURVE SMOOTH",
-"258 613 LINE",
-"256 614 LINE",
-"248 613 OFFCURVE",
-"224 600 OFFCURVE",
-"224 593 CURVE SMOOTH",
-"224 533 OFFCURVE",
-"223 474 OFFCURVE",
-"221 418 CURVE",
-"153 417 OFFCURVE",
-"102 415 OFFCURVE",
-"70 411 CURVE SMOOTH",
-"69 411 OFFCURVE",
-"68 410 OFFCURVE",
-"67 409 CURVE",
-"70 401 OFFCURVE",
-"92 386 OFFCURVE",
-"100 386 CURVE SMOOTH",
-"98 386 OFFCURVE",
-"111 387 OFFCURVE",
-"141 389 CURVE SMOOTH",
-"220 393 LINE",
-"216 334 OFFCURVE",
-"209 250 OFFCURVE",
-"200 143 CURVE SMOOTH",
-"193 54 LINE SMOOTH",
-"191 30 OFFCURVE",
-"190 18 OFFCURVE",
-"190 17 CURVE SMOOTH",
-"190 13 OFFCURVE",
-"191 11 OFFCURVE",
-"194 11 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"196 11 OFFCURVE",
-"197 12 OFFCURVE",
-"198 14 CURVE",
-"207 50 OFFCURVE",
-"212 79 OFFCURVE",
-"214 100 CURVE SMOOTH",
-"225 182 OFFCURVE",
-"236 280 OFFCURVE",
-"246 394 CURVE",
-"305 397 OFFCURVE",
-"357 398 OFFCURVE",
-"400 398 CURVE SMOOTH",
-"407 398 OFFCURVE",
-"411 400 OFFCURVE",
-"411 403 CURVE SMOOTH",
-"411 404 OFFCURVE",
-"409 405 OFFCURVE",
-"406 406 CURVE SMOOTH",
-"373 413 OFFCURVE",
-"320 417 OFFCURVE",
-"248 418 CURVE",
-"255 499 OFFCURVE",
-"258 557 OFFCURVE",
-"258 594 CURVE SMOOTH",
-"258 613 LINE",
-"256 614 LINE",
-"248 613 OFFCURVE",
-"224 600 OFFCURVE",
-"224 593 CURVE SMOOTH",
-"224 533 OFFCURVE",
-"223 474 OFFCURVE",
-"221 418 CURVE",
-"153 417 OFFCURVE",
-"102 415 OFFCURVE",
-"70 411 CURVE SMOOTH",
-"69 411 OFFCURVE",
-"68 410 OFFCURVE",
-"67 409 CURVE",
-"70 401 OFFCURVE",
-"92 386 OFFCURVE",
-"100 386 CURVE SMOOTH",
-"141 389 LINE",
-"220 393 LINE",
-"216 334 OFFCURVE",
-"209 250 OFFCURVE",
-"200 143 CURVE SMOOTH",
-"193 54 LINE",
-"190 17 LINE SMOOTH",
-"190 13 OFFCURVE",
-"191 11 OFFCURVE",
-"194 11 CURVE SMOOTH"
-);
-}
-);
-width = 387;
-}
-);
-leftKerningGroup = dagger;
-note = dagger;
-rightKerningGroup = dagger;
-unicode = 2020;
-},
-{
-glyphname = daggerdbl;
-lastChange = "2022-02-14 17:04:14 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"208 2 OFFCURVE",
-"209 3 OFFCURVE",
-"211 5 CURVE",
-"226 90 OFFCURVE",
-"239 165 OFFCURVE",
-"245 230 CURVE",
-"307 232 OFFCURVE",
-"361 234 OFFCURVE",
-"404 234 CURVE SMOOTH",
-"411 234 OFFCURVE",
-"416 235 OFFCURVE",
-"416 239 CURVE SMOOTH",
-"416 241 OFFCURVE",
-"414 241 OFFCURVE",
-"410 242 CURVE SMOOTH",
-"379 249 OFFCURVE",
-"323 254 OFFCURVE",
-"248 255 CURVE",
-"254 301 OFFCURVE",
-"259 346 OFFCURVE",
-"263 392 CURVE",
-"323 393 OFFCURVE",
-"376 395 OFFCURVE",
-"420 395 CURVE SMOOTH",
-"427 395 OFFCURVE",
-"431 396 OFFCURVE",
-"431 400 CURVE SMOOTH",
-"431 402 OFFCURVE",
-"430 403 OFFCURVE",
-"426 404 CURVE SMOOTH",
-"393 411 OFFCURVE",
-"339 414 OFFCURVE",
-"265 416 CURVE",
-"273 502 OFFCURVE",
-"277 562 OFFCURVE",
-"277 599 CURVE SMOOTH",
-"277 605 OFFCURVE",
-"277 609 OFFCURVE",
-"276 613 CURVE SMOOTH",
-"275 615 LINE",
-"268 615 OFFCURVE",
-"242 601 OFFCURVE",
-"242 594 CURVE SMOOTH",
-"242 535 OFFCURVE",
-"241 476 OFFCURVE",
-"238 416 CURVE",
-"165 414 OFFCURVE",
-"115 413 OFFCURVE",
-"84 409 CURVE SMOOTH",
-"83 409 OFFCURVE",
-"82 409 OFFCURVE",
-"82 407 CURVE SMOOTH",
-"83 397 OFFCURVE",
-"105 383 OFFCURVE",
-"115 383 CURVE SMOOTH",
-"130 383 OFFCURVE",
-"150 385 OFFCURVE",
-"175 386 CURVE SMOOTH",
-"207 388 OFFCURVE",
-"228 389 OFFCURVE",
-"236 390 CURVE",
-"225 255 LINE",
-"154 254 OFFCURVE",
-"101 252 OFFCURVE",
-"70 248 CURVE SMOOTH",
-"68 248 OFFCURVE",
-"68 247 OFFCURVE",
-"67 245 CURVE",
-"68 238 OFFCURVE",
-"90 223 OFFCURVE",
-"100 223 CURVE SMOOTH",
-"115 223 OFFCURVE",
-"135 224 OFFCURVE",
-"161 225 CURVE SMOOTH",
-"194 227 OFFCURVE",
-"214 228 OFFCURVE",
-"222 230 CURVE",
-"209 83 LINE SMOOTH",
-"205 35 OFFCURVE",
-"202 10 OFFCURVE",
-"202 9 CURVE SMOOTH",
-"202 5 OFFCURVE",
-"204 2 OFFCURVE",
-"207 2 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"208 2 OFFCURVE",
-"209 3 OFFCURVE",
-"211 5 CURVE",
-"226 90 OFFCURVE",
-"239 165 OFFCURVE",
-"245 230 CURVE",
-"307 232 OFFCURVE",
-"361 234 OFFCURVE",
-"404 234 CURVE SMOOTH",
-"411 234 OFFCURVE",
-"416 235 OFFCURVE",
-"416 239 CURVE SMOOTH",
-"416 241 OFFCURVE",
-"414 241 OFFCURVE",
-"410 242 CURVE SMOOTH",
-"379 249 OFFCURVE",
-"323 254 OFFCURVE",
-"248 255 CURVE",
-"254 301 OFFCURVE",
-"259 346 OFFCURVE",
-"263 392 CURVE",
-"323 393 OFFCURVE",
-"376 395 OFFCURVE",
-"420 395 CURVE SMOOTH",
-"427 395 OFFCURVE",
-"431 396 OFFCURVE",
-"431 400 CURVE SMOOTH",
-"431 402 OFFCURVE",
-"430 403 OFFCURVE",
-"426 404 CURVE SMOOTH",
-"393 411 OFFCURVE",
-"339 414 OFFCURVE",
-"265 416 CURVE",
-"273 502 OFFCURVE",
-"277 562 OFFCURVE",
-"277 599 CURVE SMOOTH",
-"277 605 OFFCURVE",
-"277 609 OFFCURVE",
-"276 613 CURVE SMOOTH",
-"275 615 LINE",
-"268 615 OFFCURVE",
-"242 601 OFFCURVE",
-"242 594 CURVE SMOOTH",
-"242 535 OFFCURVE",
-"241 476 OFFCURVE",
-"238 416 CURVE",
-"165 414 OFFCURVE",
-"115 413 OFFCURVE",
-"84 409 CURVE SMOOTH",
-"83 409 OFFCURVE",
-"82 409 OFFCURVE",
-"82 407 CURVE SMOOTH",
-"83 397 OFFCURVE",
-"105 383 OFFCURVE",
-"115 383 CURVE SMOOTH",
-"130 383 OFFCURVE",
-"150 385 OFFCURVE",
-"175 386 CURVE SMOOTH",
-"207 388 OFFCURVE",
-"228 389 OFFCURVE",
-"236 390 CURVE",
-"225 255 LINE",
-"154 254 OFFCURVE",
-"101 252 OFFCURVE",
-"70 248 CURVE SMOOTH",
-"68 248 OFFCURVE",
-"68 247 OFFCURVE",
-"67 245 CURVE",
-"68 238 OFFCURVE",
-"90 223 OFFCURVE",
-"100 223 CURVE SMOOTH",
-"115 223 OFFCURVE",
-"135 224 OFFCURVE",
-"161 225 CURVE SMOOTH",
-"194 227 OFFCURVE",
-"214 228 OFFCURVE",
-"222 230 CURVE",
-"209 83 LINE SMOOTH",
-"205 35 OFFCURVE",
-"202 10 OFFCURVE",
-"202 9 CURVE SMOOTH",
-"202 5 OFFCURVE",
-"204 2 OFFCURVE",
-"207 2 CURVE SMOOTH"
-);
-}
-);
-width = 407;
-}
-);
-leftKerningGroup = dagger;
-note = daggerdbl;
-rightKerningGroup = dagger;
-unicode = 2021;
-},
-{
-glyphname = numero;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"191 -75 OFFCURVE",
-"211 -72 OFFCURVE",
-"227 -67 CURVE SMOOTH",
-"347 -23 OFFCURVE",
-"430 103 OFFCURVE",
-"480 213 CURVE SMOOTH",
-"502 263 OFFCURVE",
-"524 314 OFFCURVE",
-"542 365 CURVE",
-"554 336 OFFCURVE",
-"565 306 OFFCURVE",
-"576 277 CURVE SMOOTH",
-"592 234 OFFCURVE",
-"609 191 OFFCURVE",
-"625 148 CURVE SMOOTH",
-"644 101 OFFCURVE",
-"665 42 OFFCURVE",
-"700 4 CURVE SMOOTH",
-"732 -34 OFFCURVE",
-"761 -33 OFFCURVE",
-"780 -33 CURVE SMOOTH",
-"804 -33 OFFCURVE",
-"861 -20 OFFCURVE",
-"861 13 CURVE SMOOTH",
-"861 21 OFFCURVE",
-"856 25 OFFCURVE",
-"847 25 CURVE SMOOTH",
-"838 25 OFFCURVE",
-"832 18 OFFCURVE",
-"825 10 CURVE SMOOTH",
-"817 -1 OFFCURVE",
-"807 -13 OFFCURVE",
-"791 -13 CURVE SMOOTH",
-"774 -13 OFFCURVE",
-"753 2 OFFCURVE",
-"743 21 CURVE",
-"742 25 OFFCURVE",
-"742 31 OFFCURVE",
-"742 38 CURVE SMOOTH",
-"742 141 OFFCURVE",
-"845 438 OFFCURVE",
-"898 514 CURVE SMOOTH",
-"915 538 OFFCURVE",
-"948 569 OFFCURVE",
-"977 569 CURVE SMOOTH",
-"987 569 OFFCURVE",
-"992 564 OFFCURVE",
-"997 558 CURVE SMOOTH",
-"1000 555 OFFCURVE",
-"1002 553 OFFCURVE",
-"1006 551 CURVE",
-"1007 551 LINE SMOOTH",
-"1010 551 OFFCURVE",
-"1012 553 OFFCURVE",
-"1012 555 CURVE SMOOTH",
-"1012 558 OFFCURVE",
-"1011 559 OFFCURVE",
-"1009 562 CURVE SMOOTH",
-"1008 564 OFFCURVE",
-"1008 564 OFFCURVE",
-"1008 565 CURVE",
-"1000 576 OFFCURVE",
-"981 583 OFFCURVE",
-"960 583 CURVE SMOOTH",
-"854 583 OFFCURVE",
-"786 369 OFFCURVE",
-"759 292 CURVE SMOOTH",
-"737 223 OFFCURVE",
-"715 154 OFFCURVE",
-"703 85 CURVE",
-"695 99 OFFCURVE",
-"688 114 OFFCURVE",
-"681 130 CURVE SMOOTH",
-"677 140 OFFCURVE",
-"673 150 OFFCURVE",
-"668 160 CURVE SMOOTH",
-"647 212 OFFCURVE",
-"625 263 OFFCURVE",
-"605 316 CURVE SMOOTH",
-"592 347 OFFCURVE",
-"580 378 OFFCURVE",
-"567 410 CURVE SMOOTH",
-"566 413 OFFCURVE",
-"564 418 OFFCURVE",
-"562 422 CURVE",
-"566 435 OFFCURVE",
-"573 458 OFFCURVE",
-"573 471 CURVE SMOOTH",
-"573 475 OFFCURVE",
-"567 480 OFFCURVE",
-"563 480 CURVE SMOOTH",
-"558 480 OFFCURVE",
-"551 476 OFFCURVE",
-"541 467 CURVE",
-"507 532 OFFCURVE",
-"447 602 OFFCURVE",
-"368 602 CURVE SMOOTH",
-"305 602 OFFCURVE",
-"246 553 OFFCURVE",
-"219 501 CURVE SMOOTH",
-"210 482 OFFCURVE",
-"200 462 OFFCURVE",
-"200 442 CURVE SMOOTH",
-"200 432 OFFCURVE",
-"202 423 OFFCURVE",
-"209 423 CURVE SMOOTH",
-"213 423 OFFCURVE",
-"215 426 OFFCURVE",
-"218 431 CURVE SMOOTH",
-"220 436 OFFCURVE",
-"221 440 OFFCURVE",
-"222 446 CURVE",
-"222 447 OFFCURVE",
-"222 449 OFFCURVE",
-"223 451 CURVE",
-"227 468 OFFCURVE",
-"231 486 OFFCURVE",
-"240 501 CURVE SMOOTH",
-"265 546 OFFCURVE",
-"307 572 OFFCURVE",
-"352 572 CURVE SMOOTH",
-"436 572 OFFCURVE",
-"487 496 OFFCURVE",
-"519 425 CURVE",
-"501 363 OFFCURVE",
-"474 301 OFFCURVE",
-"449 243 CURVE SMOOTH",
-"360 51 OFFCURVE",
-"264 -57 OFFCURVE",
-"174 -57 CURVE SMOOTH",
-"86 -57 OFFCURVE",
-"42 35 OFFCURVE",
-"32 111 CURVE SMOOTH",
-"31 117 OFFCURVE",
-"31 122 OFFCURVE",
-"31 128 CURVE SMOOTH",
-"31 143 LINE SMOOTH",
-"31 153 OFFCURVE",
-"29 169 OFFCURVE",
-"22 169 CURVE SMOOTH",
-"12 169 OFFCURVE",
-"6 136 OFFCURVE",
-"6 100 CURVE SMOOTH",
-"6 60 OFFCURVE",
-"14 26 OFFCURVE",
-"28 -1 CURVE SMOOTH",
-"55 -51 OFFCURVE",
-"117 -75 OFFCURVE",
-"173 -75 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"901 170 OFFCURVE",
-"921 172 OFFCURVE",
-"942 174 CURVE SMOOTH",
-"950 174 OFFCURVE",
-"958 175 OFFCURVE",
-"966 175 CURVE SMOOTH",
-"984 176 OFFCURVE",
-"1001 177 OFFCURVE",
-"1020 177 CURVE SMOOTH",
-"1027 177 OFFCURVE",
-"1030 185 OFFCURVE",
-"1030 187 CURVE SMOOTH",
-"1030 196 OFFCURVE",
-"986 201 OFFCURVE",
-"941 201 CURVE SMOOTH",
-"923 201 OFFCURVE",
-"873 202 OFFCURVE",
-"860 194 CURVE",
-"858 192 LINE",
-"857 189 OFFCURVE",
-"868 170 OFFCURVE",
-"877 170 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"959 236 OFFCURVE",
-"1028 274 OFFCURVE",
-"1048 300 CURVE SMOOTH",
-"1080 341 OFFCURVE",
-"1119 438 OFFCURVE",
-"1119 490 CURVE SMOOTH",
-"1119 499 OFFCURVE",
-"1117 505 OFFCURVE",
-"1112 510 CURVE",
-"1104 515 OFFCURVE",
-"1090 518 OFFCURVE",
-"1078 518 CURVE SMOOTH",
-"1036 518 OFFCURVE",
-"980 486 OFFCURVE",
-"956 454 CURVE SMOOTH",
-"923 409 OFFCURVE",
-"899 335 OFFCURVE",
-"899 277 CURVE SMOOTH",
-"899 258 OFFCURVE",
-"899 236 OFFCURVE",
-"927 236 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"945 263 OFFCURVE",
-"943 272 OFFCURVE",
-"943 284 CURVE SMOOTH",
-"943 340 OFFCURVE",
-"971 412 OFFCURVE",
-"998 458 CURVE",
-"1000 460 OFFCURVE",
-"1001 462 OFFCURVE",
-"1005 466 CURVE",
-"1007 471 OFFCURVE",
-"1010 476 OFFCURVE",
-"1013 479 CURVE SMOOTH",
-"1020 487 OFFCURVE",
-"1038 494 OFFCURVE",
-"1048 494 CURVE SMOOTH",
-"1053 494 OFFCURVE",
-"1063 492 OFFCURVE",
-"1067 489 CURVE",
-"1067 489 OFFCURVE",
-"1068 484 OFFCURVE",
-"1068 478 CURVE SMOOTH",
-"1068 423 OFFCURVE",
-"1036 332 OFFCURVE",
-"1003 294 CURVE SMOOTH",
-"988 276 OFFCURVE",
-"972 266 OFFCURVE",
-"947 261 CURVE"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"191 -75 OFFCURVE",
-"211 -72 OFFCURVE",
-"227 -67 CURVE SMOOTH",
-"347 -23 OFFCURVE",
-"430 103 OFFCURVE",
-"480 213 CURVE SMOOTH",
-"502 263 OFFCURVE",
-"524 314 OFFCURVE",
-"542 365 CURVE",
-"554 336 OFFCURVE",
-"565 306 OFFCURVE",
-"576 277 CURVE SMOOTH",
-"625 148 LINE SMOOTH",
-"644 101 OFFCURVE",
-"665 42 OFFCURVE",
-"700 4 CURVE SMOOTH",
-"730 -32 OFFCURVE",
-"758 -33 OFFCURVE",
-"777 -33 CURVE SMOOTH",
-"799 -33 OFFCURVE",
-"861 -20 OFFCURVE",
-"861 13 CURVE SMOOTH",
-"861 21 OFFCURVE",
-"856 25 OFFCURVE",
-"847 25 CURVE SMOOTH",
-"838 25 OFFCURVE",
-"832 18 OFFCURVE",
-"825 10 CURVE SMOOTH",
-"817 -1 OFFCURVE",
-"807 -13 OFFCURVE",
-"791 -13 CURVE SMOOTH",
-"774 -13 OFFCURVE",
-"753 2 OFFCURVE",
-"743 21 CURVE",
-"742 25 OFFCURVE",
-"742 31 OFFCURVE",
-"742 38 CURVE SMOOTH",
-"742 141 OFFCURVE",
-"845 438 OFFCURVE",
-"898 514 CURVE SMOOTH",
-"915 538 OFFCURVE",
-"948 569 OFFCURVE",
-"977 569 CURVE SMOOTH",
-"987 569 OFFCURVE",
-"992 564 OFFCURVE",
-"997 558 CURVE SMOOTH",
-"1000 555 OFFCURVE",
-"1002 553 OFFCURVE",
-"1006 551 CURVE",
-"1007 551 LINE SMOOTH",
-"1010 551 OFFCURVE",
-"1012 553 OFFCURVE",
-"1012 555 CURVE SMOOTH",
-"1012 558 OFFCURVE",
-"1011 559 OFFCURVE",
-"1009 562 CURVE SMOOTH",
-"1008 564 OFFCURVE",
-"1008 564 OFFCURVE",
-"1008 565 CURVE",
-"1000 576 OFFCURVE",
-"981 583 OFFCURVE",
-"960 583 CURVE SMOOTH",
-"854 583 OFFCURVE",
-"786 369 OFFCURVE",
-"759 292 CURVE SMOOTH",
-"737 223 OFFCURVE",
-"715 154 OFFCURVE",
-"703 85 CURVE",
-"695 99 OFFCURVE",
-"688 114 OFFCURVE",
-"681 130 CURVE SMOOTH",
-"677 140 OFFCURVE",
-"673 150 OFFCURVE",
-"668 160 CURVE SMOOTH",
-"647 212 OFFCURVE",
-"625 263 OFFCURVE",
-"605 316 CURVE SMOOTH",
-"592 347 OFFCURVE",
-"580 378 OFFCURVE",
-"567 410 CURVE SMOOTH",
-"566 413 OFFCURVE",
-"564 418 OFFCURVE",
-"562 422 CURVE",
-"566 435 OFFCURVE",
-"573 458 OFFCURVE",
-"573 471 CURVE SMOOTH",
-"573 475 OFFCURVE",
-"567 480 OFFCURVE",
-"563 480 CURVE SMOOTH",
-"558 480 OFFCURVE",
-"551 476 OFFCURVE",
-"541 467 CURVE",
-"507 532 OFFCURVE",
-"447 602 OFFCURVE",
-"368 602 CURVE SMOOTH",
-"305 602 OFFCURVE",
-"246 553 OFFCURVE",
-"219 501 CURVE SMOOTH",
-"210 482 OFFCURVE",
-"200 462 OFFCURVE",
-"200 442 CURVE SMOOTH",
-"200 432 OFFCURVE",
-"202 423 OFFCURVE",
-"209 423 CURVE SMOOTH",
-"213 423 OFFCURVE",
-"215 426 OFFCURVE",
-"218 431 CURVE SMOOTH",
-"220 436 OFFCURVE",
-"221 440 OFFCURVE",
-"222 446 CURVE SMOOTH",
-"222 447 OFFCURVE",
-"222 449 OFFCURVE",
-"223 451 CURVE",
-"227 468 OFFCURVE",
-"231 486 OFFCURVE",
-"240 501 CURVE SMOOTH",
-"265 546 OFFCURVE",
-"307 572 OFFCURVE",
-"352 572 CURVE SMOOTH",
-"436 572 OFFCURVE",
-"487 496 OFFCURVE",
-"519 425 CURVE",
-"501 363 OFFCURVE",
-"474 301 OFFCURVE",
-"449 243 CURVE SMOOTH",
-"360 51 OFFCURVE",
-"264 -57 OFFCURVE",
-"174 -57 CURVE SMOOTH",
-"86 -57 OFFCURVE",
-"42 35 OFFCURVE",
-"32 111 CURVE SMOOTH",
-"31 117 OFFCURVE",
-"31 122 OFFCURVE",
-"31 128 CURVE SMOOTH",
-"31 143 LINE SMOOTH",
-"31 153 OFFCURVE",
-"29 169 OFFCURVE",
-"22 169 CURVE SMOOTH",
-"12 169 OFFCURVE",
-"6 136 OFFCURVE",
-"6 100 CURVE SMOOTH",
-"6 60 OFFCURVE",
-"14 26 OFFCURVE",
-"28 -1 CURVE SMOOTH",
-"55 -51 OFFCURVE",
-"117 -75 OFFCURVE",
-"173 -75 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"901 170 OFFCURVE",
-"921 172 OFFCURVE",
-"942 174 CURVE SMOOTH",
-"950 174 OFFCURVE",
-"958 175 OFFCURVE",
-"966 175 CURVE SMOOTH",
-"984 176 OFFCURVE",
-"1001 177 OFFCURVE",
-"1020 177 CURVE SMOOTH",
-"1027 177 OFFCURVE",
-"1030 185 OFFCURVE",
-"1030 187 CURVE SMOOTH",
-"1030 197 OFFCURVE",
-"977 201 OFFCURVE",
-"927 201 CURVE SMOOTH",
-"904 201 OFFCURVE",
-"870 200 OFFCURVE",
-"860 194 CURVE",
-"858 192 LINE",
-"857 189 OFFCURVE",
-"868 170 OFFCURVE",
-"877 170 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"959 236 OFFCURVE",
-"1028 274 OFFCURVE",
-"1048 300 CURVE SMOOTH",
-"1080 341 OFFCURVE",
-"1119 438 OFFCURVE",
-"1119 490 CURVE SMOOTH",
-"1119 499 OFFCURVE",
-"1117 505 OFFCURVE",
-"1112 510 CURVE",
-"1104 515 OFFCURVE",
-"1090 518 OFFCURVE",
-"1078 518 CURVE SMOOTH",
-"1036 518 OFFCURVE",
-"980 486 OFFCURVE",
-"956 454 CURVE SMOOTH",
-"923 409 OFFCURVE",
-"899 335 OFFCURVE",
-"899 277 CURVE SMOOTH",
-"899 258 OFFCURVE",
-"899 236 OFFCURVE",
-"927 236 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"945 263 OFFCURVE",
-"943 272 OFFCURVE",
-"943 284 CURVE SMOOTH",
-"943 340 OFFCURVE",
-"971 412 OFFCURVE",
-"998 458 CURVE",
-"1000 460 OFFCURVE",
-"1001 462 OFFCURVE",
-"1005 466 CURVE",
-"1007 471 OFFCURVE",
-"1010 476 OFFCURVE",
-"1013 479 CURVE SMOOTH",
-"1020 487 OFFCURVE",
-"1038 494 OFFCURVE",
-"1048 494 CURVE SMOOTH",
-"1053 494 OFFCURVE",
-"1063 492 OFFCURVE",
-"1067 489 CURVE",
-"1067 489 OFFCURVE",
-"1068 484 OFFCURVE",
-"1068 478 CURVE SMOOTH",
-"1068 423 OFFCURVE",
-"1036 332 OFFCURVE",
-"1003 294 CURVE SMOOTH",
-"988 276 OFFCURVE",
-"972 266 OFFCURVE",
-"947 261 CURVE"
-);
-}
-);
-width = 1068;
-}
-);
-unicode = 2116;
+unicode = 27E9;
 },
 {
 glyphname = cedi;
@@ -54703,6 +51177,162 @@ width = 509;
 }
 );
 unicode = 20AC;
+},
+{
+glyphname = florin;
+lastChange = "2022-02-14 21:32:36 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-25 -261 OFFCURVE",
+"14 -181 OFFCURVE",
+"101 104 CURVE",
+"121 106 OFFCURVE",
+"139 107 OFFCURVE",
+"153 107 CURVE SMOOTH",
+"156 107 OFFCURVE",
+"157 108 OFFCURVE",
+"157 109 CURVE SMOOTH",
+"157 114 OFFCURVE",
+"140 118 OFFCURVE",
+"106 119 CURVE",
+"132 188 OFFCURVE",
+"151 237 OFFCURVE",
+"165 266 CURVE SMOOTH",
+"201 341 OFFCURVE",
+"231 380 OFFCURVE",
+"256 380 CURVE SMOOTH",
+"272 380 OFFCURVE",
+"280 363 OFFCURVE",
+"280 330 CURVE SMOOTH",
+"280 320 LINE SMOOTH",
+"280 314 OFFCURVE",
+"281 312 OFFCURVE",
+"282 312 CURVE SMOOTH",
+"289 312 OFFCURVE",
+"294 321 OFFCURVE",
+"294 341 CURVE SMOOTH",
+"294 368 OFFCURVE",
+"272 388 OFFCURVE",
+"243 388 CURVE SMOOTH",
+"194 388 OFFCURVE",
+"151 332 OFFCURVE",
+"113 220 CURVE SMOOTH",
+"100 175 OFFCURVE",
+"90 141 OFFCURVE",
+"83 119 CURVE",
+"68 118 OFFCURVE",
+"52 117 OFFCURVE",
+"34 114 CURVE",
+"33 113 LINE",
+"35 104 OFFCURVE",
+"40 100 OFFCURVE",
+"46 100 CURVE SMOOTH",
+"41 100 OFFCURVE",
+"52 100 OFFCURVE",
+"79 102 CURVE",
+"69 65 OFFCURVE",
+"59 36 OFFCURVE",
+"47 0 CURVE SMOOTH",
+"-6 -162 OFFCURVE",
+"-64 -244 OFFCURVE",
+"-128 -244 CURVE SMOOTH",
+"-156 -244 OFFCURVE",
+"-173 -212 OFFCURVE",
+"-179 -145 CURVE SMOOTH",
+"-180 -139 OFFCURVE",
+"-181 -134 OFFCURVE",
+"-183 -134 CURVE SMOOTH",
+"-193 -134 OFFCURVE",
+"-198 -148 OFFCURVE",
+"-198 -177 CURVE SMOOTH",
+"-198 -223 OFFCURVE",
+"-166 -261 OFFCURVE",
+"-121 -261 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"-25 -261 OFFCURVE",
+"14 -181 OFFCURVE",
+"101 104 CURVE",
+"121 106 OFFCURVE",
+"139 107 OFFCURVE",
+"153 107 CURVE SMOOTH",
+"156 107 OFFCURVE",
+"157 108 OFFCURVE",
+"157 109 CURVE SMOOTH",
+"157 114 OFFCURVE",
+"140 118 OFFCURVE",
+"106 119 CURVE",
+"132 188 OFFCURVE",
+"151 237 OFFCURVE",
+"165 266 CURVE SMOOTH",
+"201 341 OFFCURVE",
+"231 380 OFFCURVE",
+"256 380 CURVE SMOOTH",
+"272 380 OFFCURVE",
+"280 363 OFFCURVE",
+"280 330 CURVE SMOOTH",
+"280 320 LINE SMOOTH",
+"280 314 OFFCURVE",
+"281 312 OFFCURVE",
+"282 312 CURVE SMOOTH",
+"289 312 OFFCURVE",
+"294 321 OFFCURVE",
+"294 341 CURVE SMOOTH",
+"294 368 OFFCURVE",
+"272 388 OFFCURVE",
+"243 388 CURVE SMOOTH",
+"194 388 OFFCURVE",
+"151 332 OFFCURVE",
+"113 220 CURVE SMOOTH",
+"83 119 LINE",
+"68 118 OFFCURVE",
+"52 117 OFFCURVE",
+"34 114 CURVE",
+"33 113 LINE",
+"35 103 OFFCURVE",
+"45 100 OFFCURVE",
+"45 100 CURVE",
+"45 100 OFFCURVE",
+"56 100 OFFCURVE",
+"79 102 CURVE",
+"69 65 OFFCURVE",
+"59 36 OFFCURVE",
+"47 0 CURVE SMOOTH",
+"-6 -162 OFFCURVE",
+"-64 -244 OFFCURVE",
+"-128 -244 CURVE SMOOTH",
+"-156 -244 OFFCURVE",
+"-173 -212 OFFCURVE",
+"-179 -145 CURVE SMOOTH",
+"-180 -139 OFFCURVE",
+"-181 -134 OFFCURVE",
+"-183 -134 CURVE SMOOTH",
+"-193 -134 OFFCURVE",
+"-198 -148 OFFCURVE",
+"-198 -177 CURVE SMOOTH",
+"-198 -223 OFFCURVE",
+"-166 -261 OFFCURVE",
+"-121 -261 CURVE SMOOTH"
+);
+}
+);
+width = 292;
+}
+);
+note = florin;
+unicode = 0192;
 },
 {
 color = 3;
@@ -63150,367 +59780,1074 @@ note = lozenge;
 unicode = 25CA;
 },
 {
-color = 3;
-glyphname = brevecomb_acutecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
+glyphname = apple;
+lastChange = "2022-02-07 18:28:46 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
 background = {
-components = (
+paths = (
 {
-name = brevecomb;
+closed = 1;
+nodes = (
+"229 83 OFFCURVE",
+"247 88 OFFCURVE",
+"260 99 CURVE",
+"272 106 OFFCURVE",
+"288 110 OFFCURVE",
+"306 110 CURVE SMOOTH",
+"326 110 OFFCURVE",
+"341 106 OFFCURVE",
+"354 99 CURVE SMOOTH",
+"370 88 OFFCURVE",
+"387 83 OFFCURVE",
+"408 83 CURVE SMOOTH",
+"430 83 OFFCURVE",
+"458 102 OFFCURVE",
+"490 141 CURVE SMOOTH",
+"518 175 OFFCURVE",
+"537 208 OFFCURVE",
+"546 240 CURVE",
+"492 261 OFFCURVE",
+"464 304 OFFCURVE",
+"464 365 CURVE SMOOTH",
+"464 417 OFFCURVE",
+"487 456 OFFCURVE",
+"531 481 CURVE",
+"504 522 OFFCURVE",
+"467 542 OFFCURVE",
+"421 542 CURVE SMOOTH",
+"409 542 OFFCURVE",
+"400 542 OFFCURVE",
+"395 540 CURVE SMOOTH",
+"382 534 OFFCURVE",
+"361 527 OFFCURVE",
+"333 520 CURVE SMOOTH",
+"322 517 OFFCURVE",
+"311 516 OFFCURVE",
+"301 516 CURVE SMOOTH",
+"295 516 OFFCURVE",
+"288 516 OFFCURVE",
+"282 518 CURVE SMOOTH",
+"258 526 OFFCURVE",
+"236 533 OFFCURVE",
+"219 540 CURVE SMOOTH",
+"216 541 OFFCURVE",
+"210 542 OFFCURVE",
+"199 542 CURVE SMOOTH",
+"149 542 OFFCURVE",
+"108 514 OFFCURVE",
+"78 461 CURVE SMOOTH",
+"60 429 OFFCURVE",
+"52 393 OFFCURVE",
+"52 351 CURVE SMOOTH",
+"52 270 OFFCURVE",
+"76 200 OFFCURVE",
+"124 141 CURVE SMOOTH",
+"156 102 OFFCURVE",
+"183 83 OFFCURVE",
+"207 83 CURVE SMOOTH"
+);
 },
 {
-name = acutecomb;
-transform = "{1, 0, 0, 1, 89, 93}";
+closed = 1;
+nodes = (
+"341 532 OFFCURVE",
+"369 546 OFFCURVE",
+"392 575 CURVE SMOOTH",
+"413 602 OFFCURVE",
+"423 631 OFFCURVE",
+"423 663 CURVE SMOOTH",
+"423 673 OFFCURVE",
+"422 679 OFFCURVE",
+"422 681 CURVE",
+"413 684 OFFCURVE",
+"401 681 OFFCURVE",
+"384 672 CURVE SMOOTH",
+"371 665 OFFCURVE",
+"360 658 OFFCURVE",
+"351 649 CURVE SMOOTH",
+"323 621 OFFCURVE",
+"308 586 OFFCURVE",
+"308 548 CURVE SMOOTH",
+"308 543 OFFCURVE",
+"309 539 OFFCURVE",
+"311 533 CURVE"
+);
 }
 );
 };
-components = (
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
 {
-name = brevecomb;
+closed = 1;
+nodes = (
+"229 83 OFFCURVE",
+"247 88 OFFCURVE",
+"260 99 CURVE",
+"272 106 OFFCURVE",
+"288 110 OFFCURVE",
+"306 110 CURVE SMOOTH",
+"326 110 OFFCURVE",
+"341 106 OFFCURVE",
+"354 99 CURVE SMOOTH",
+"370 88 OFFCURVE",
+"387 83 OFFCURVE",
+"408 83 CURVE SMOOTH",
+"430 83 OFFCURVE",
+"458 102 OFFCURVE",
+"490 141 CURVE SMOOTH",
+"518 175 OFFCURVE",
+"537 208 OFFCURVE",
+"546 240 CURVE",
+"492 261 OFFCURVE",
+"464 304 OFFCURVE",
+"464 365 CURVE SMOOTH",
+"464 417 OFFCURVE",
+"487 456 OFFCURVE",
+"531 481 CURVE",
+"504 522 OFFCURVE",
+"467 542 OFFCURVE",
+"421 542 CURVE SMOOTH",
+"409 542 OFFCURVE",
+"400 542 OFFCURVE",
+"395 540 CURVE SMOOTH",
+"382 534 OFFCURVE",
+"361 527 OFFCURVE",
+"333 520 CURVE SMOOTH",
+"322 517 OFFCURVE",
+"311 516 OFFCURVE",
+"301 516 CURVE SMOOTH",
+"295 516 OFFCURVE",
+"288 516 OFFCURVE",
+"282 518 CURVE SMOOTH",
+"258 526 OFFCURVE",
+"236 533 OFFCURVE",
+"219 540 CURVE SMOOTH",
+"216 541 OFFCURVE",
+"210 542 OFFCURVE",
+"199 542 CURVE SMOOTH",
+"149 542 OFFCURVE",
+"108 514 OFFCURVE",
+"78 461 CURVE SMOOTH",
+"60 429 OFFCURVE",
+"52 393 OFFCURVE",
+"52 351 CURVE SMOOTH",
+"52 270 OFFCURVE",
+"76 200 OFFCURVE",
+"124 141 CURVE SMOOTH",
+"156 102 OFFCURVE",
+"183 83 OFFCURVE",
+"207 83 CURVE SMOOTH"
+);
 },
 {
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 50, 100}";
+closed = 1;
+nodes = (
+"341 532 OFFCURVE",
+"369 546 OFFCURVE",
+"392 575 CURVE SMOOTH",
+"413 602 OFFCURVE",
+"423 631 OFFCURVE",
+"423 663 CURVE SMOOTH",
+"423 673 OFFCURVE",
+"422 679 OFFCURVE",
+"422 681 CURVE",
+"413 684 OFFCURVE",
+"401 681 OFFCURVE",
+"384 672 CURVE SMOOTH",
+"371 665 OFFCURVE",
+"360 658 OFFCURVE",
+"351 649 CURVE SMOOTH",
+"323 621 OFFCURVE",
+"308 586 OFFCURVE",
+"308 548 CURVE SMOOTH",
+"308 543 OFFCURVE",
+"309 539 OFFCURVE",
+"311 533 CURVE"
+);
 }
 );
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
+width = 577;
 }
 );
+note = apple;
+unicode = F8FF;
 },
 {
 color = 3;
-glyphname = brevecomb_gravecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
+glyphname = at;
+lastChange = "2022-02-14 19:26:37 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
 background = {
-components = (
+paths = (
 {
-name = brevecomb;
-transform = "{1, 0, 0, 1, 44, 0}";
+closed = 1;
+nodes = (
+"399 27 OFFCURVE",
+"470 43 OFFCURVE",
+"544 73 CURVE SMOOTH",
+"622 105 OFFCURVE",
+"682 146 OFFCURVE",
+"722 196 CURVE SMOOTH",
+"752 230 OFFCURVE",
+"766 263 OFFCURVE",
+"766 296 CURVE SMOOTH",
+"766 339 OFFCURVE",
+"751 377 OFFCURVE",
+"720 410 CURVE",
+"721 420 OFFCURVE",
+"722 429 OFFCURVE",
+"722 438 CURVE SMOOTH",
+"722 500 OFFCURVE",
+"702 546 OFFCURVE",
+"662 581 CURVE SMOOTH",
+"625 613 OFFCURVE",
+"575 629 OFFCURVE",
+"514 629 CURVE SMOOTH",
+"409 629 OFFCURVE",
+"311 594 OFFCURVE",
+"218 523 CURVE SMOOTH",
+"119 447 OFFCURVE",
+"70 358 OFFCURVE",
+"70 258 CURVE SMOOTH",
+"70 219 OFFCURVE",
+"78 181 OFFCURVE",
+"93 145 CURVE SMOOTH",
+"111 105 OFFCURVE",
+"144 75 OFFCURVE",
+"194 54 CURVE SMOOTH",
+"235 36 OFFCURVE",
+"280 27 OFFCURVE",
+"330 27 CURVE SMOOTH"
+);
 },
 {
-name = gravecomb;
-transform = "{1, 0, 0, 1, 0, 90}";
+closed = 1;
+nodes = (
+"236 175 OFFCURVE",
+"226 184 OFFCURVE",
+"226 203 CURVE SMOOTH",
+"226 247 OFFCURVE",
+"260 311 OFFCURVE",
+"328 394 CURVE SMOOTH",
+"397 477 OFFCURVE",
+"452 519 OFFCURVE",
+"495 519 CURVE SMOOTH",
+"512 519 OFFCURVE",
+"521 509 OFFCURVE",
+"521 491 CURVE SMOOTH",
+"521 472 OFFCURVE",
+"514 455 OFFCURVE",
+"501 436 CURVE",
+"506 448 OFFCURVE",
+"508 457 OFFCURVE",
+"508 463 CURVE SMOOTH",
+"508 471 OFFCURVE",
+"505 475 OFFCURVE",
+"499 475 CURVE SMOOTH",
+"485 475 OFFCURVE",
+"471 463 OFFCURVE",
+"454 440 CURVE SMOOTH",
+"438 418 OFFCURVE",
+"429 398 OFFCURVE",
+"427 383 CURVE",
+"388 361 LINE",
+"376 357 OFFCURVE",
+"370 353 OFFCURVE",
+"370 349 CURVE SMOOTH",
+"370 346 OFFCURVE",
+"372 344 OFFCURVE",
+"376 344 CURVE SMOOTH",
+"385 344 OFFCURVE",
+"396 346 OFFCURVE",
+"408 351 CURVE",
+"359 233 OFFCURVE",
+"307 175 OFFCURVE",
+"254 175 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 42 OFFCURVE",
+"208 57 OFFCURVE",
+"166 86 CURVE SMOOTH",
+"118 120 OFFCURVE",
+"93 169 OFFCURVE",
+"93 233 CURVE SMOOTH",
+"93 326 OFFCURVE",
+"145 411 OFFCURVE",
+"248 489 CURVE SMOOTH",
+"345 562 OFFCURVE",
+"441 599 OFFCURVE",
+"538 599 CURVE SMOOTH",
+"626 599 OFFCURVE",
+"679 563 OFFCURVE",
+"696 492 CURVE SMOOTH",
+"698 483 OFFCURVE",
+"699 473 OFFCURVE",
+"699 464 CURVE SMOOTH",
+"699 454 OFFCURVE",
+"698 443 OFFCURVE",
+"695 431 CURVE",
+"674 446 OFFCURVE",
+"653 453 OFFCURVE",
+"634 453 CURVE SMOOTH",
+"623 453 OFFCURVE",
+"618 450 OFFCURVE",
+"618 445 CURVE SMOOTH",
+"618 444 OFFCURVE",
+"619 444 OFFCURVE",
+"620 443 CURVE",
+"648 430 OFFCURVE",
+"670 414 OFFCURVE",
+"686 393 CURVE",
+"679 364 OFFCURVE",
+"667 333 OFFCURVE",
+"650 300 CURVE SMOOTH",
+"632 263 OFFCURVE",
+"610 229 OFFCURVE",
+"584 195 CURVE SMOOTH",
+"547 148 OFFCURVE",
+"516 125 OFFCURVE",
+"490 125 CURVE SMOOTH",
+"464 125 OFFCURVE",
+"451 152 OFFCURVE",
+"451 206 CURVE SMOOTH",
+"451 271 OFFCURVE",
+"463 334 OFFCURVE",
+"487 393 CURVE",
+"535 428 OFFCURVE",
+"560 463 OFFCURVE",
+"560 500 CURVE SMOOTH",
+"560 528 OFFCURVE",
+"543 542 OFFCURVE",
+"510 542 CURVE SMOOTH",
+"483 542 OFFCURVE",
+"453 534 OFFCURVE",
+"418 517 CURVE SMOOTH",
+"363 492 OFFCURVE",
+"314 448 OFFCURVE",
+"269 385 CURVE SMOOTH",
+"221 320 OFFCURVE",
+"198 260 OFFCURVE",
+"198 202 CURVE SMOOTH",
+"198 157 OFFCURVE",
+"215 135 OFFCURVE",
+"249 135 CURVE SMOOTH",
+"305 135 OFFCURVE",
+"360 194 OFFCURVE",
+"413 312 CURVE",
+"404 275 OFFCURVE",
+"401 244 OFFCURVE",
+"401 219 CURVE SMOOTH",
+"401 206 OFFCURVE",
+"401 194 OFFCURVE",
+"403 184 CURVE SMOOTH",
+"411 144 OFFCURVE",
+"444 105 OFFCURVE",
+"482 105 CURVE SMOOTH",
+"524 105 OFFCURVE",
+"569 140 OFFCURVE",
+"618 209 CURVE SMOOTH",
+"657 264 OFFCURVE",
+"685 318 OFFCURVE",
+"702 370 CURVE",
+"714 347 OFFCURVE",
+"720 325 OFFCURVE",
+"720 301 CURVE SMOOTH",
+"720 289 OFFCURVE",
+"718 276 OFFCURVE",
+"714 264 CURVE SMOOTH",
+"690 197 OFFCURVE",
+"638 141 OFFCURVE",
+"557 100 CURVE SMOOTH",
+"483 61 OFFCURVE",
+"407 42 OFFCURVE",
+"330 42 CURVE SMOOTH"
+);
 }
 );
 };
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = gravecomb;
-transform = "{1, 0, 0, 1, 20, 100}";
-}
-);
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
+paths = (
+{
+closed = 1;
+nodes = (
+"399 -107 OFFCURVE",
+"470 -91 OFFCURVE",
+"544 -61 CURVE SMOOTH",
+"622 -29 OFFCURVE",
+"682 12 OFFCURVE",
+"722 62 CURVE SMOOTH",
+"752 96 OFFCURVE",
+"766 129 OFFCURVE",
+"766 162 CURVE SMOOTH",
+"766 205 OFFCURVE",
+"751 243 OFFCURVE",
+"720 276 CURVE",
+"721 286 OFFCURVE",
+"722 295 OFFCURVE",
+"722 304 CURVE SMOOTH",
+"722 366 OFFCURVE",
+"702 412 OFFCURVE",
+"662 447 CURVE SMOOTH",
+"625 479 OFFCURVE",
+"575 495 OFFCURVE",
+"514 495 CURVE SMOOTH",
+"409 495 OFFCURVE",
+"311 460 OFFCURVE",
+"218 389 CURVE SMOOTH",
+"119 313 OFFCURVE",
+"70 224 OFFCURVE",
+"70 124 CURVE SMOOTH",
+"70 85 OFFCURVE",
+"78 47 OFFCURVE",
+"93 11 CURVE SMOOTH",
+"111 -29 OFFCURVE",
+"144 -59 OFFCURVE",
+"194 -80 CURVE SMOOTH",
+"235 -98 OFFCURVE",
+"280 -107 OFFCURVE",
+"330 -107 CURVE SMOOTH"
 );
 },
 {
-color = 3;
-glyphname = brevecomb_hookabovecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
+closed = 1;
+nodes = (
+"236 41 OFFCURVE",
+"226 50 OFFCURVE",
+"226 69 CURVE SMOOTH",
+"226 113 OFFCURVE",
+"260 177 OFFCURVE",
+"328 260 CURVE SMOOTH",
+"397 343 OFFCURVE",
+"452 385 OFFCURVE",
+"495 385 CURVE SMOOTH",
+"512 385 OFFCURVE",
+"521 375 OFFCURVE",
+"521 357 CURVE SMOOTH",
+"521 338 OFFCURVE",
+"514 321 OFFCURVE",
+"501 302 CURVE",
+"506 314 OFFCURVE",
+"508 323 OFFCURVE",
+"508 329 CURVE SMOOTH",
+"508 337 OFFCURVE",
+"505 341 OFFCURVE",
+"499 341 CURVE SMOOTH",
+"485 341 OFFCURVE",
+"471 329 OFFCURVE",
+"454 306 CURVE SMOOTH",
+"438 284 OFFCURVE",
+"429 264 OFFCURVE",
+"427 249 CURVE",
+"388 227 LINE",
+"376 223 OFFCURVE",
+"370 219 OFFCURVE",
+"370 215 CURVE SMOOTH",
+"370 212 OFFCURVE",
+"372 210 OFFCURVE",
+"376 210 CURVE SMOOTH",
+"385 210 OFFCURVE",
+"396 212 OFFCURVE",
+"408 217 CURVE",
+"359 99 OFFCURVE",
+"307 41 OFFCURVE",
+"254 41 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 -92 OFFCURVE",
+"208 -77 OFFCURVE",
+"166 -48 CURVE SMOOTH",
+"118 -14 OFFCURVE",
+"93 35 OFFCURVE",
+"93 99 CURVE SMOOTH",
+"93 192 OFFCURVE",
+"145 277 OFFCURVE",
+"248 355 CURVE SMOOTH",
+"345 428 OFFCURVE",
+"441 465 OFFCURVE",
+"538 465 CURVE SMOOTH",
+"626 465 OFFCURVE",
+"679 429 OFFCURVE",
+"696 358 CURVE SMOOTH",
+"698 349 OFFCURVE",
+"699 339 OFFCURVE",
+"699 330 CURVE SMOOTH",
+"699 320 OFFCURVE",
+"698 309 OFFCURVE",
+"695 297 CURVE",
+"674 312 OFFCURVE",
+"653 319 OFFCURVE",
+"634 319 CURVE SMOOTH",
+"623 319 OFFCURVE",
+"618 316 OFFCURVE",
+"618 311 CURVE SMOOTH",
+"618 310 OFFCURVE",
+"619 310 OFFCURVE",
+"620 309 CURVE",
+"648 296 OFFCURVE",
+"670 280 OFFCURVE",
+"686 259 CURVE",
+"679 230 OFFCURVE",
+"667 199 OFFCURVE",
+"650 166 CURVE SMOOTH",
+"632 129 OFFCURVE",
+"610 95 OFFCURVE",
+"584 61 CURVE SMOOTH",
+"547 14 OFFCURVE",
+"516 -9 OFFCURVE",
+"490 -9 CURVE SMOOTH",
+"464 -9 OFFCURVE",
+"451 18 OFFCURVE",
+"451 72 CURVE SMOOTH",
+"451 137 OFFCURVE",
+"463 200 OFFCURVE",
+"487 259 CURVE",
+"535 294 OFFCURVE",
+"560 329 OFFCURVE",
+"560 366 CURVE SMOOTH",
+"560 394 OFFCURVE",
+"543 408 OFFCURVE",
+"510 408 CURVE SMOOTH",
+"483 408 OFFCURVE",
+"453 400 OFFCURVE",
+"418 383 CURVE SMOOTH",
+"363 358 OFFCURVE",
+"314 314 OFFCURVE",
+"269 251 CURVE SMOOTH",
+"221 186 OFFCURVE",
+"198 126 OFFCURVE",
+"198 68 CURVE SMOOTH",
+"198 23 OFFCURVE",
+"215 1 OFFCURVE",
+"249 1 CURVE SMOOTH",
+"305 1 OFFCURVE",
+"360 60 OFFCURVE",
+"413 178 CURVE",
+"404 141 OFFCURVE",
+"401 110 OFFCURVE",
+"401 85 CURVE SMOOTH",
+"401 72 OFFCURVE",
+"401 60 OFFCURVE",
+"403 50 CURVE SMOOTH",
+"411 10 OFFCURVE",
+"444 -29 OFFCURVE",
+"482 -29 CURVE SMOOTH",
+"524 -29 OFFCURVE",
+"569 6 OFFCURVE",
+"618 75 CURVE SMOOTH",
+"657 130 OFFCURVE",
+"685 184 OFFCURVE",
+"702 236 CURVE",
+"714 213 OFFCURVE",
+"720 191 OFFCURVE",
+"720 167 CURVE SMOOTH",
+"720 155 OFFCURVE",
+"718 142 OFFCURVE",
+"714 130 CURVE SMOOTH",
+"690 63 OFFCURVE",
+"638 7 OFFCURVE",
+"557 -34 CURVE SMOOTH",
+"483 -73 OFFCURVE",
+"407 -92 OFFCURVE",
+"330 -92 CURVE SMOOTH"
+);
+}
+);
+width = 786;
+}
+);
+note = at;
+unicode = 0040;
+},
+{
+glyphname = ampersand;
+lastChange = "2022-02-14 19:24:06 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
 background = {
-components = (
+paths = (
 {
-name = brevecomb;
+closed = 1;
+nodes = (
+"304 -236 OFFCURVE",
+"384 -145 OFFCURVE",
+"440 35 CURVE",
+"536 65 OFFCURVE",
+"615 115 OFFCURVE",
+"677 186 CURVE SMOOTH",
+"723 239 OFFCURVE",
+"746 283 OFFCURVE",
+"746 317 CURVE SMOOTH",
+"746 357 OFFCURVE",
+"719 378 OFFCURVE",
+"665 378 CURVE SMOOTH",
+"613 378 OFFCURVE",
+"558 359 OFFCURVE",
+"503 321 CURVE",
+"520 403 OFFCURVE",
+"534 458 OFFCURVE",
+"544 484 CURVE",
+"622 530 OFFCURVE",
+"661 569 OFFCURVE",
+"661 602 CURVE SMOOTH",
+"661 622 OFFCURVE",
+"652 631 OFFCURVE",
+"635 631 CURVE SMOOTH",
+"621 631 OFFCURVE",
+"603 622 OFFCURVE",
+"584 601 CURVE SMOOTH",
+"571 588 OFFCURVE",
+"558 570 OFFCURVE",
+"546 544 CURVE SMOOTH",
+"541 532 OFFCURVE",
+"532 510 OFFCURVE",
+"521 480 CURVE",
+"458 447 OFFCURVE",
+"394 414 OFFCURVE",
+"331 380 CURVE SMOOTH",
+"260 341 OFFCURVE",
+"201 301 OFFCURVE",
+"153 257 CURVE",
+"133 279 OFFCURVE",
+"122 304 OFFCURVE",
+"122 335 CURVE SMOOTH",
+"122 382 OFFCURVE",
+"147 423 OFFCURVE",
+"198 458 CURVE SMOOTH",
+"243 488 OFFCURVE",
+"291 503 OFFCURVE",
+"342 503 CURVE SMOOTH",
+"356 503 OFFCURVE",
+"389 495 OFFCURVE",
+"402 495 CURVE SMOOTH",
+"403 495 OFFCURVE",
+"404 496 OFFCURVE",
+"405 498 CURVE",
+"405 506 OFFCURVE",
+"383 511 OFFCURVE",
+"338 511 CURVE SMOOTH",
+"282 511 OFFCURVE",
+"229 495 OFFCURVE",
+"179 462 CURVE SMOOTH",
+"121 426 OFFCURVE",
+"93 382 OFFCURVE",
+"93 330 CURVE SMOOTH",
+"93 295 OFFCURVE",
+"106 264 OFFCURVE",
+"134 239 CURVE",
+"82 187 OFFCURVE",
+"57 142 OFFCURVE",
+"57 103 CURVE SMOOTH",
+"57 65 OFFCURVE",
+"80 37 OFFCURVE",
+"128 20 CURVE SMOOTH",
+"162 7 OFFCURVE",
+"202 0 OFFCURVE",
+"248 0 CURVE SMOOTH",
+"294 0 OFFCURVE",
+"342 6 OFFCURVE",
+"391 19 CURVE",
+"332 -142 OFFCURVE",
+"264 -222 OFFCURVE",
+"190 -222 CURVE SMOOTH",
+"152 -222 OFFCURVE",
+"130 -206 OFFCURVE",
+"125 -173 CURVE",
+"124 -170 OFFCURVE",
+"123 -169 OFFCURVE",
+"121 -169 CURVE SMOOTH",
+"118 -169 OFFCURVE",
+"117 -170 OFFCURVE",
+"117 -173 CURVE SMOOTH",
+"117 -193 OFFCURVE",
+"127 -209 OFFCURVE",
+"145 -221 CURVE SMOOTH",
+"161 -231 OFFCURVE",
+"180 -236 OFFCURVE",
+"202 -236 CURVE SMOOTH"
+);
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 75, 86}";
+closed = 1;
+nodes = (
+"243 20 OFFCURVE",
+"208 26 OFFCURVE",
+"179 38 CURVE SMOOTH",
+"139 55 OFFCURVE",
+"119 81 OFFCURVE",
+"119 116 CURVE SMOOTH",
+"119 145 OFFCURVE",
+"134 179 OFFCURVE",
+"164 217 CURVE",
+"191 201 OFFCURVE",
+"221 193 OFFCURVE",
+"252 193 CURVE SMOOTH",
+"314 193 OFFCURVE",
+"386 226 OFFCURVE",
+"468 292 CURVE",
+"439 173 OFFCURVE",
+"415 87 OFFCURVE",
+"395 34 CURVE",
+"357 25 OFFCURVE",
+"320 20 OFFCURVE",
+"284 20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 213 OFFCURVE",
+"204 221 OFFCURVE",
+"180 235 CURVE",
+"231 293 OFFCURVE",
+"297 345 OFFCURVE",
+"376 392 CURVE SMOOTH",
+"438 426 OFFCURVE",
+"485 452 OFFCURVE",
+"517 468 CURVE",
+"504 426 OFFCURVE",
+"488 371 OFFCURVE",
+"471 301 CURVE",
+"378 242 OFFCURVE",
+"306 213 OFFCURVE",
+"259 213 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 164 OFFCURVE",
+"489 251 OFFCURVE",
+"500 309 CURVE",
+"543 332 OFFCURVE",
+"585 342 OFFCURVE",
+"628 342 CURVE SMOOTH",
+"682 342 OFFCURVE",
+"709 325 OFFCURVE",
+"709 289 CURVE SMOOTH",
+"709 261 OFFCURVE",
+"689 222 OFFCURVE",
+"649 177 CURVE SMOOTH",
+"598 119 OFFCURVE",
+"530 76 OFFCURVE",
+"443 50 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"571 542 OFFCURVE",
+"588 572 OFFCURVE",
+"604 586 CURVE SMOOTH",
+"618 599 OFFCURVE",
+"627 605 OFFCURVE",
+"634 605 CURVE SMOOTH",
+"639 605 OFFCURVE",
+"642 601 OFFCURVE",
+"642 594 CURVE SMOOTH",
+"642 583 OFFCURVE",
+"629 565 OFFCURVE",
+"604 541 CURVE SMOOTH",
+"584 520 OFFCURVE",
+"565 505 OFFCURVE",
+"550 497 CURVE"
+);
 }
 );
 };
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 40, 100}";
-}
-);
 layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
+paths = (
+{
+closed = 1;
+nodes = (
+"304 -236 OFFCURVE",
+"384 -145 OFFCURVE",
+"440 35 CURVE",
+"536 65 OFFCURVE",
+"615 115 OFFCURVE",
+"677 186 CURVE SMOOTH",
+"723 239 OFFCURVE",
+"746 283 OFFCURVE",
+"746 317 CURVE SMOOTH",
+"746 357 OFFCURVE",
+"719 378 OFFCURVE",
+"665 378 CURVE SMOOTH",
+"613 378 OFFCURVE",
+"558 359 OFFCURVE",
+"503 321 CURVE",
+"520 403 OFFCURVE",
+"534 458 OFFCURVE",
+"544 484 CURVE",
+"622 530 OFFCURVE",
+"661 569 OFFCURVE",
+"661 602 CURVE SMOOTH",
+"661 622 OFFCURVE",
+"652 631 OFFCURVE",
+"635 631 CURVE SMOOTH",
+"621 631 OFFCURVE",
+"603 622 OFFCURVE",
+"584 601 CURVE SMOOTH",
+"571 588 OFFCURVE",
+"558 570 OFFCURVE",
+"546 544 CURVE SMOOTH",
+"541 532 OFFCURVE",
+"532 510 OFFCURVE",
+"521 480 CURVE",
+"458 447 OFFCURVE",
+"394 414 OFFCURVE",
+"331 380 CURVE SMOOTH",
+"260 341 OFFCURVE",
+"201 301 OFFCURVE",
+"153 257 CURVE",
+"133 279 OFFCURVE",
+"122 304 OFFCURVE",
+"122 335 CURVE SMOOTH",
+"122 382 OFFCURVE",
+"147 423 OFFCURVE",
+"198 458 CURVE SMOOTH",
+"243 488 OFFCURVE",
+"291 503 OFFCURVE",
+"342 503 CURVE SMOOTH",
+"356 503 OFFCURVE",
+"389 495 OFFCURVE",
+"402 495 CURVE SMOOTH",
+"403 495 OFFCURVE",
+"404 496 OFFCURVE",
+"405 498 CURVE",
+"405 506 OFFCURVE",
+"383 511 OFFCURVE",
+"338 511 CURVE SMOOTH",
+"282 511 OFFCURVE",
+"229 495 OFFCURVE",
+"179 462 CURVE SMOOTH",
+"121 426 OFFCURVE",
+"93 382 OFFCURVE",
+"93 330 CURVE SMOOTH",
+"93 295 OFFCURVE",
+"106 264 OFFCURVE",
+"134 239 CURVE",
+"82 187 OFFCURVE",
+"57 142 OFFCURVE",
+"57 103 CURVE SMOOTH",
+"57 65 OFFCURVE",
+"80 37 OFFCURVE",
+"128 20 CURVE SMOOTH",
+"162 7 OFFCURVE",
+"202 0 OFFCURVE",
+"248 0 CURVE SMOOTH",
+"294 0 OFFCURVE",
+"342 6 OFFCURVE",
+"391 19 CURVE",
+"332 -142 OFFCURVE",
+"264 -222 OFFCURVE",
+"190 -222 CURVE SMOOTH",
+"152 -222 OFFCURVE",
+"130 -206 OFFCURVE",
+"125 -173 CURVE",
+"124 -170 OFFCURVE",
+"123 -169 OFFCURVE",
+"121 -169 CURVE SMOOTH",
+"118 -169 OFFCURVE",
+"117 -170 OFFCURVE",
+"117 -173 CURVE SMOOTH",
+"117 -193 OFFCURVE",
+"127 -209 OFFCURVE",
+"145 -221 CURVE SMOOTH",
+"161 -231 OFFCURVE",
+"180 -236 OFFCURVE",
+"202 -236 CURVE SMOOTH"
 );
 },
 {
-color = 3;
-glyphname = brevecomb_tildecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = brevecomb;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 23, 108}";
-}
-);
-};
-components = (
-{
-name = brevecomb;
-},
-{
-alignment = -1;
-name = tildecomb;
-transform = "{1, 0, 0, 1, 50, 120}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
+closed = 1;
+nodes = (
+"243 20 OFFCURVE",
+"208 26 OFFCURVE",
+"179 38 CURVE SMOOTH",
+"139 55 OFFCURVE",
+"119 81 OFFCURVE",
+"119 116 CURVE SMOOTH",
+"119 145 OFFCURVE",
+"134 179 OFFCURVE",
+"164 217 CURVE",
+"191 201 OFFCURVE",
+"221 193 OFFCURVE",
+"252 193 CURVE SMOOTH",
+"314 193 OFFCURVE",
+"386 226 OFFCURVE",
+"468 292 CURVE",
+"439 173 OFFCURVE",
+"415 87 OFFCURVE",
+"395 34 CURVE",
+"357 25 OFFCURVE",
+"320 20 OFFCURVE",
+"284 20 CURVE SMOOTH"
 );
 },
 {
-color = 3;
-glyphname = circumflexcomb_acutecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = circumflexcomb;
-},
-{
-name = acutecomb;
-transform = "{1, 0, 0, 1, 214, 100}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 100, 90}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
+closed = 1;
+nodes = (
+"230 213 OFFCURVE",
+"204 221 OFFCURVE",
+"180 235 CURVE",
+"231 293 OFFCURVE",
+"297 345 OFFCURVE",
+"376 392 CURVE SMOOTH",
+"438 426 OFFCURVE",
+"485 452 OFFCURVE",
+"517 468 CURVE",
+"504 426 OFFCURVE",
+"488 371 OFFCURVE",
+"471 301 CURVE",
+"378 242 OFFCURVE",
+"306 213 OFFCURVE",
+"259 213 CURVE SMOOTH"
 );
 },
 {
-color = 3;
-glyphname = circumflexcomb_gravecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = circumflexcomb;
-},
-{
-name = gravecomb;
-transform = "{1, 0, 0, 1, 153, 99}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = gravecomb;
-transform = "{1, 0, 0, 1, 101, 100}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
+closed = 1;
+nodes = (
+"470 164 OFFCURVE",
+"489 251 OFFCURVE",
+"500 309 CURVE",
+"543 332 OFFCURVE",
+"585 342 OFFCURVE",
+"628 342 CURVE SMOOTH",
+"682 342 OFFCURVE",
+"709 325 OFFCURVE",
+"709 289 CURVE SMOOTH",
+"709 261 OFFCURVE",
+"689 222 OFFCURVE",
+"649 177 CURVE SMOOTH",
+"598 119 OFFCURVE",
+"530 76 OFFCURVE",
+"443 50 CURVE"
 );
 },
 {
-color = 3;
-glyphname = circumflexcomb_hookabovecomb;
-lastChange = "2022-02-11 09:05:24 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
+closed = 1;
+nodes = (
+"571 542 OFFCURVE",
+"588 572 OFFCURVE",
+"604 586 CURVE SMOOTH",
+"618 599 OFFCURVE",
+"627 605 OFFCURVE",
+"634 605 CURVE SMOOTH",
+"639 605 OFFCURVE",
+"642 601 OFFCURVE",
+"642 594 CURVE SMOOTH",
+"642 583 OFFCURVE",
+"629 565 OFFCURVE",
+"604 541 CURVE SMOOTH",
+"584 520 OFFCURVE",
+"565 505 OFFCURVE",
+"550 497 CURVE"
+);
 }
 );
-background = {
-components = (
-{
-name = circumflexcomb;
+width = 739;
+}
+);
+note = ampersand;
+unicode = 0026;
 },
 {
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 209, 88}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-alignment = -1;
-name = hookabovecomb;
-transform = "{1, 0, 0, 1, 100, 80}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = circumflexcomb_tildecomb;
-lastChange = "2022-02-11 08:56:48 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = circumflexcomb;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 53, 103}";
-}
-);
-};
-components = (
-{
-name = circumflexcomb;
-},
-{
-name = tildecomb;
-transform = "{1, 0, 0, 1, 0, 140}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = dieresiscomb;
+glyphname = paragraph;
 lastChange = "2022-02-14 21:32:36 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"167 735 OFFCURVE",
-"177 755 OFFCURVE",
-"181 767 CURVE SMOOTH",
-"183 779 OFFCURVE",
-"193 788 OFFCURVE",
-"204 804 CURVE",
-"204 808 LINE",
-"203 811 OFFCURVE",
-"200 811 OFFCURVE",
-"199 811 CURVE SMOOTH",
-"184 811 OFFCURVE",
-"131 786 OFFCURVE",
-"131 765 CURVE SMOOTH",
-"131 756 OFFCURVE",
-"141 735 OFFCURVE",
-"151 735 CURVE SMOOTH"
+"76 -193 OFFCURVE",
+"111 -175 OFFCURVE",
+"142 -138 CURVE",
+"148 -138 LINE SMOOTH",
+"216 -141 OFFCURVE",
+"273 -78 OFFCURVE",
+"319 51 CURVE SMOOTH",
+"337 102 OFFCURVE",
+"364 211 OFFCURVE",
+"398 376 CURVE SMOOTH",
+"418 478 OFFCURVE",
+"436 549 OFFCURVE",
+"450 590 CURVE SMOOTH",
+"475 664 OFFCURVE",
+"502 703 OFFCURVE",
+"532 703 CURVE SMOOTH",
+"542 703 OFFCURVE",
+"546 708 OFFCURVE",
+"544 721 CURVE SMOOTH",
+"544 731 OFFCURVE",
+"536 736 OFFCURVE",
+"523 736 CURVE SMOOTH",
+"492 736 OFFCURVE",
+"462 708 OFFCURVE",
+"437 655 CURVE",
+"424 649 OFFCURVE",
+"406 646 OFFCURVE",
+"382 646 CURVE SMOOTH",
+"326 646 OFFCURVE",
+"275 633 OFFCURVE",
+"231 609 CURVE SMOOTH",
+"178 579 OFFCURVE",
+"142 534 OFFCURVE",
+"121 474 CURVE SMOOTH",
+"108 437 OFFCURVE",
+"104 399 OFFCURVE",
+"108 361 CURVE SMOOTH",
+"113 316 OFFCURVE",
+"129 282 OFFCURVE",
+"156 256 CURVE SMOOTH",
+"179 233 OFFCURVE",
+"207 221 OFFCURVE",
+"238 217 CURVE",
+"212 103 OFFCURVE",
+"189 20 OFFCURVE",
+"168 -31 CURVE SMOOTH",
+"128 -124 OFFCURVE",
+"81 -170 OFFCURVE",
+"26 -170 CURVE SMOOTH",
+"14 -170 OFFCURVE",
+"9 -173 OFFCURVE",
+"10 -180 CURVE SMOOTH",
+"10 -189 OFFCURVE",
+"19 -193 OFFCURVE",
+"37 -193 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"36 735 OFFCURVE",
-"46 755 OFFCURVE",
-"50 767 CURVE SMOOTH",
-"53 779 OFFCURVE",
-"62 788 OFFCURVE",
-"73 804 CURVE",
-"73 808 LINE",
-"72 811 OFFCURVE",
-"69 811 OFFCURVE",
-"68 811 CURVE SMOOTH",
-"54 811 OFFCURVE",
-"0 786 OFFCURVE",
-"0 765 CURVE SMOOTH",
-"0 756 OFFCURVE",
-"10 735 OFFCURVE",
-"20 735 CURVE SMOOTH"
+"190 -69 OFFCURVE",
+"221 11 OFFCURVE",
+"251 122 CURVE SMOOTH",
+"317 406 LINE SMOOTH",
+"343 507 OFFCURVE",
+"370 574 OFFCURVE",
+"398 607 CURVE",
+"419 609 LINE",
+"408 576 OFFCURVE",
+"397 537 OFFCURVE",
+"387 491 CURVE SMOOTH",
+"380 466 OFFCURVE",
+"372 425 OFFCURVE",
+"362 366 CURVE SMOOTH",
+"343 275 OFFCURVE",
+"332 215 OFFCURVE",
+"325 183 CURVE SMOOTH",
+"282 -10 OFFCURVE",
+"224 -111 OFFCURVE",
+"156 -120 CURVE"
 );
 }
 );
@@ -63520,90 +60857,229 @@ paths = (
 {
 closed = 1;
 nodes = (
-"65 344 OFFCURVE",
-"75 364 OFFCURVE",
-"79 376 CURVE",
-"81 388 OFFCURVE",
-"91 397 OFFCURVE",
-"102 413 CURVE",
-"102 417 LINE",
-"101 420 OFFCURVE",
-"98 420 OFFCURVE",
-"97 420 CURVE SMOOTH",
-"82 420 OFFCURVE",
-"29 395 OFFCURVE",
-"29 374 CURVE SMOOTH",
-"29 365 OFFCURVE",
-"39 344 OFFCURVE",
-"49 344 CURVE SMOOTH"
+"76 -193 OFFCURVE",
+"111 -175 OFFCURVE",
+"142 -138 CURVE",
+"148 -138 LINE SMOOTH",
+"216 -141 OFFCURVE",
+"273 -78 OFFCURVE",
+"319 51 CURVE SMOOTH",
+"337 102 OFFCURVE",
+"364 211 OFFCURVE",
+"398 376 CURVE SMOOTH",
+"418 478 OFFCURVE",
+"436 549 OFFCURVE",
+"450 590 CURVE SMOOTH",
+"475 664 OFFCURVE",
+"502 703 OFFCURVE",
+"532 703 CURVE SMOOTH",
+"540 703 OFFCURVE",
+"544 706 OFFCURVE",
+"545 715 CURVE SMOOTH",
+"545 717 OFFCURVE",
+"544 719 OFFCURVE",
+"544 721 CURVE SMOOTH",
+"544 731 OFFCURVE",
+"536 736 OFFCURVE",
+"523 736 CURVE SMOOTH",
+"492 736 OFFCURVE",
+"462 708 OFFCURVE",
+"437 655 CURVE",
+"424 649 OFFCURVE",
+"406 646 OFFCURVE",
+"382 646 CURVE SMOOTH",
+"326 646 OFFCURVE",
+"275 633 OFFCURVE",
+"231 609 CURVE SMOOTH",
+"178 579 OFFCURVE",
+"142 534 OFFCURVE",
+"121 474 CURVE SMOOTH",
+"111 446 OFFCURVE",
+"107 418 OFFCURVE",
+"107 389 CURVE SMOOTH",
+"107 330 OFFCURVE",
+"123 287 OFFCURVE",
+"156 256 CURVE SMOOTH",
+"179 233 OFFCURVE",
+"207 221 OFFCURVE",
+"238 217 CURVE",
+"212 103 OFFCURVE",
+"189 20 OFFCURVE",
+"168 -31 CURVE SMOOTH",
+"128 -124 OFFCURVE",
+"81 -170 OFFCURVE",
+"26 -170 CURVE SMOOTH",
+"15 -170 OFFCURVE",
+"10 -173 OFFCURVE",
+"10 -179 CURVE SMOOTH",
+"10 -180 LINE SMOOTH",
+"10 -189 OFFCURVE",
+"19 -193 OFFCURVE",
+"37 -193 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"-66 344 OFFCURVE",
-"-56 364 OFFCURVE",
-"-52 376 CURVE SMOOTH",
-"-49 388 OFFCURVE",
-"-40 397 OFFCURVE",
-"-29 413 CURVE",
-"-29 417 LINE",
-"-30 420 OFFCURVE",
-"-33 420 OFFCURVE",
-"-34 420 CURVE SMOOTH",
-"-48 420 OFFCURVE",
-"-102 395 OFFCURVE",
-"-102 374 CURVE SMOOTH",
-"-102 365 OFFCURVE",
-"-92 344 OFFCURVE",
-"-82 344 CURVE SMOOTH"
+"190 -69 OFFCURVE",
+"221 11 OFFCURVE",
+"251 122 CURVE",
+"317 406 LINE SMOOTH",
+"343 507 OFFCURVE",
+"370 574 OFFCURVE",
+"398 607 CURVE",
+"419 609 LINE",
+"408 576 OFFCURVE",
+"397 537 OFFCURVE",
+"387 491 CURVE SMOOTH",
+"380 466 OFFCURVE",
+"372 425 OFFCURVE",
+"362 366 CURVE SMOOTH",
+"343 275 OFFCURVE",
+"332 215 OFFCURVE",
+"325 183 CURVE SMOOTH",
+"282 -10 OFFCURVE",
+"224 -111 OFFCURVE",
+"156 -120 CURVE"
 );
 }
 );
-width = 0;
+width = 465;
 }
 );
-unicode = 0308;
+note = paragraph;
+unicode = 00B6;
 },
 {
-color = 3;
-glyphname = dotaccentcomb;
-lastChange = "2022-02-10 20:26:23 +0000";
+glyphname = section;
+lastChange = "2022-02-07 18:28:46 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"32 744 OFFCURVE",
-"47 749 OFFCURVE",
-"54 761 CURVE SMOOTH",
-"60 772 OFFCURVE",
-"64 783 OFFCURVE",
-"64 789 CURVE SMOOTH",
-"64 801 OFFCURVE",
-"57 808 OFFCURVE",
-"39 808 CURVE SMOOTH",
-"20 808 OFFCURVE",
-"0 787 OFFCURVE",
-"0 762 CURVE SMOOTH",
-"0 759 OFFCURVE",
-"0 756 OFFCURVE",
-"1 753 CURVE SMOOTH",
-"2 747 OFFCURVE",
-"11 744 OFFCURVE",
-"20 744 CURVE SMOOTH"
+"231 -174 OFFCURVE",
+"280 -162 OFFCURVE",
+"325 -140 CURVE SMOOTH",
+"375 -114 OFFCURVE",
+"409 -79 OFFCURVE",
+"428 -35 CURVE",
+"505 5 OFFCURVE",
+"543 63 OFFCURVE",
+"543 140 CURVE SMOOTH",
+"543 189 OFFCURVE",
+"525 230 OFFCURVE",
+"489 263 CURVE",
+"388 337 LINE SMOOTH",
+"352 365 OFFCURVE",
+"335 397 OFFCURVE",
+"335 433 CURVE SMOOTH",
+"335 469 OFFCURVE",
+"349 500 OFFCURVE",
+"378 522 CURVE SMOOTH",
+"404 542 OFFCURVE",
+"436 553 OFFCURVE",
+"474 553 CURVE SMOOTH",
+"534 553 OFFCURVE",
+"564 535 OFFCURVE",
+"564 497 CURVE SMOOTH",
+"564 468 OFFCURVE",
+"540 447 OFFCURVE",
+"509 447 CURVE SMOOTH",
+"500 447 OFFCURVE",
+"495 445 OFFCURVE",
+"495 442 CURVE SMOOTH",
+"495 439 OFFCURVE",
+"500 438 OFFCURVE",
+"508 438 CURVE SMOOTH",
+"566 438 OFFCURVE",
+"595 456 OFFCURVE",
+"595 492 CURVE SMOOTH",
+"595 516 OFFCURVE",
+"581 536 OFFCURVE",
+"550 548 CURVE SMOOTH",
+"527 559 OFFCURVE",
+"502 564 OFFCURVE",
+"473 564 CURVE SMOOTH",
+"435 564 OFFCURVE",
+"399 554 OFFCURVE",
+"366 535 CURVE SMOOTH",
+"328 512 OFFCURVE",
+"306 484 OFFCURVE",
+"300 449 CURVE",
+"231 423 OFFCURVE",
+"197 382 OFFCURVE",
+"197 323 CURVE SMOOTH",
+"197 286 OFFCURVE",
+"215 253 OFFCURVE",
+"250 222 CURVE",
+"346 149 LINE",
+"381 117 OFFCURVE",
+"398 78 OFFCURVE",
+"398 34 CURVE SMOOTH",
+"398 -43 OFFCURVE",
+"360 -99 OFFCURVE",
+"285 -134 CURVE SMOOTH",
+"248 -151 OFFCURVE",
+"213 -160 OFFCURVE",
+"180 -160 CURVE SMOOTH",
+"134 -160 OFFCURVE",
+"97 -144 OFFCURVE",
+"67 -112 CURVE SMOOTH",
+"38 -80 OFFCURVE",
+"23 -41 OFFCURVE",
+"23 5 CURVE SMOOTH",
+"23 91 OFFCURVE",
+"82 149 OFFCURVE",
+"169 149 CURVE SMOOTH",
+"184 149 OFFCURVE",
+"192 150 OFFCURVE",
+"192 151 CURVE SMOOTH",
+"192 156 OFFCURVE",
+"180 158 OFFCURVE",
+"155 158 CURVE SMOOTH",
+"107 158 OFFCURVE",
+"68 141 OFFCURVE",
+"37 105 CURVE SMOOTH",
+"6 70 OFFCURVE",
+"-10 28 OFFCURVE",
+"-10 -20 CURVE SMOOTH",
+"-10 -70 OFFCURVE",
+"10 -109 OFFCURVE",
+"49 -137 CURVE SMOOTH",
+"83 -161 OFFCURVE",
+"127 -174 OFFCURVE",
+"180 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 8 OFFCURVE",
+"443 22 OFFCURVE",
+"443 38 CURVE SMOOTH",
+"443 88 OFFCURVE",
+"425 129 OFFCURVE",
+"389 162 CURVE",
+"289 234 LINE SMOOTH",
+"253 262 OFFCURVE",
+"234 295 OFFCURVE",
+"234 331 CURVE SMOOTH",
+"234 377 OFFCURVE",
+"256 412 OFFCURVE",
+"298 434 CURVE",
+"296 393 OFFCURVE",
+"312 357 OFFCURVE",
+"346 327 CURVE",
+"444 252 LINE",
+"480 220 OFFCURVE",
+"499 181 OFFCURVE",
+"499 137 CURVE SMOOTH",
+"499 74 OFFCURVE",
+"478 26 OFFCURVE",
+"438 -7 CURVE"
 );
 }
 );
@@ -63613,74 +61089,233 @@ paths = (
 {
 closed = 1;
 nodes = (
-"0 343 OFFCURVE",
-"15 348 OFFCURVE",
-"22 360 CURVE SMOOTH",
-"28 371 OFFCURVE",
-"32 382 OFFCURVE",
-"32 388 CURVE SMOOTH",
-"32 400 OFFCURVE",
-"25 407 OFFCURVE",
-"7 407 CURVE SMOOTH",
-"-12 407 OFFCURVE",
-"-32 386 OFFCURVE",
-"-32 361 CURVE SMOOTH",
-"-32 358 OFFCURVE",
-"-32 355 OFFCURVE",
-"-31 352 CURVE SMOOTH",
-"-30 346 OFFCURVE",
-"-21 343 OFFCURVE",
-"-12 343 CURVE SMOOTH"
+"231 -174 OFFCURVE",
+"280 -162 OFFCURVE",
+"325 -140 CURVE SMOOTH",
+"375 -114 OFFCURVE",
+"409 -79 OFFCURVE",
+"428 -35 CURVE",
+"505 5 OFFCURVE",
+"543 63 OFFCURVE",
+"543 140 CURVE SMOOTH",
+"543 189 OFFCURVE",
+"525 230 OFFCURVE",
+"489 263 CURVE",
+"388 337 LINE SMOOTH",
+"352 365 OFFCURVE",
+"335 397 OFFCURVE",
+"335 433 CURVE SMOOTH",
+"335 469 OFFCURVE",
+"349 500 OFFCURVE",
+"378 522 CURVE SMOOTH",
+"404 542 OFFCURVE",
+"436 553 OFFCURVE",
+"474 553 CURVE SMOOTH",
+"534 553 OFFCURVE",
+"564 535 OFFCURVE",
+"564 497 CURVE SMOOTH",
+"564 468 OFFCURVE",
+"540 447 OFFCURVE",
+"509 447 CURVE SMOOTH",
+"500 447 OFFCURVE",
+"495 445 OFFCURVE",
+"495 442 CURVE SMOOTH",
+"495 439 OFFCURVE",
+"500 438 OFFCURVE",
+"508 438 CURVE SMOOTH",
+"566 438 OFFCURVE",
+"595 456 OFFCURVE",
+"595 492 CURVE SMOOTH",
+"595 516 OFFCURVE",
+"581 536 OFFCURVE",
+"550 548 CURVE SMOOTH",
+"527 559 OFFCURVE",
+"502 564 OFFCURVE",
+"473 564 CURVE SMOOTH",
+"435 564 OFFCURVE",
+"399 554 OFFCURVE",
+"366 535 CURVE SMOOTH",
+"328 512 OFFCURVE",
+"306 484 OFFCURVE",
+"300 449 CURVE",
+"231 423 OFFCURVE",
+"197 382 OFFCURVE",
+"197 323 CURVE SMOOTH",
+"197 286 OFFCURVE",
+"215 253 OFFCURVE",
+"250 222 CURVE",
+"346 149 LINE",
+"381 117 OFFCURVE",
+"398 78 OFFCURVE",
+"398 34 CURVE SMOOTH",
+"398 -43 OFFCURVE",
+"360 -99 OFFCURVE",
+"285 -134 CURVE SMOOTH",
+"248 -151 OFFCURVE",
+"213 -160 OFFCURVE",
+"180 -160 CURVE SMOOTH",
+"134 -160 OFFCURVE",
+"97 -144 OFFCURVE",
+"67 -112 CURVE SMOOTH",
+"38 -80 OFFCURVE",
+"23 -41 OFFCURVE",
+"23 5 CURVE SMOOTH",
+"23 91 OFFCURVE",
+"82 149 OFFCURVE",
+"169 149 CURVE SMOOTH",
+"184 149 OFFCURVE",
+"192 150 OFFCURVE",
+"192 151 CURVE SMOOTH",
+"192 156 OFFCURVE",
+"180 158 OFFCURVE",
+"155 158 CURVE SMOOTH",
+"107 158 OFFCURVE",
+"68 141 OFFCURVE",
+"37 105 CURVE SMOOTH",
+"6 70 OFFCURVE",
+"-10 28 OFFCURVE",
+"-10 -20 CURVE SMOOTH",
+"-10 -70 OFFCURVE",
+"10 -109 OFFCURVE",
+"49 -137 CURVE SMOOTH",
+"83 -161 OFFCURVE",
+"127 -174 OFFCURVE",
+"180 -174 CURVE SMOOTH"
 );
-}
-);
-width = 0;
-}
-);
-unicode = 0307;
 },
 {
-color = 3;
-glyphname = gravecomb;
-lastChange = "2022-02-10 20:26:22 +0000";
+closed = 1;
+nodes = (
+"441 8 OFFCURVE",
+"443 22 OFFCURVE",
+"443 38 CURVE SMOOTH",
+"443 88 OFFCURVE",
+"425 129 OFFCURVE",
+"389 162 CURVE",
+"289 234 LINE SMOOTH",
+"253 262 OFFCURVE",
+"234 295 OFFCURVE",
+"234 331 CURVE SMOOTH",
+"234 377 OFFCURVE",
+"256 412 OFFCURVE",
+"298 434 CURVE",
+"296 393 OFFCURVE",
+"312 357 OFFCURVE",
+"346 327 CURVE",
+"444 252 LINE",
+"480 220 OFFCURVE",
+"499 181 OFFCURVE",
+"499 137 CURVE SMOOTH",
+"499 74 OFFCURVE",
+"478 26 OFFCURVE",
+"438 -7 CURVE"
+);
+}
+);
+width = 591;
+}
+);
+note = section;
+unicode = 00A7;
+},
+{
+glyphname = copyright;
+lastChange = "2022-02-14 10:09:05 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"160 735 OFFCURVE",
-"170 738 OFFCURVE",
-"170 742 CURVE SMOOTH",
-"170 743 OFFCURVE",
-"169 744 OFFCURVE",
-"166 745 CURVE",
-"130 760 OFFCURVE",
-"63 829 OFFCURVE",
-"48 839 CURVE SMOOTH",
-"43 843 OFFCURVE",
-"29 845 OFFCURVE",
-"18 845 CURVE SMOOTH",
-"8 845 OFFCURVE",
-"0 844 OFFCURVE",
-"0 839 CURVE SMOOTH",
-"1 832 OFFCURVE",
-"3 822 OFFCURVE",
-"34 802 CURVE SMOOTH",
-"39 799 OFFCURVE",
-"144 739 OFFCURVE",
-"153 738 CURVE"
+"435 28 OFFCURVE",
+"623 198 OFFCURVE",
+"609 355 CURVE SMOOTH",
+"601 448 OFFCURVE",
+"521 509 OFFCURVE",
+"429 509 CURVE SMOOTH",
+"274 509 OFFCURVE",
+"84 339 OFFCURVE",
+"98 181 CURVE SMOOTH",
+"106 89 OFFCURVE",
+"191 28 OFFCURVE",
+"283 28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 49 OFFCURVE",
+"140 99 OFFCURVE",
+"133 180 CURVE SMOOTH",
+"120 329 OFFCURVE",
+"273 490 OFFCURVE",
+"421 490 CURVE SMOOTH",
+"504 490 OFFCURVE",
+"566 430 OFFCURVE",
+"573 347 CURVE SMOOTH",
+"586 206 OFFCURVE",
+"432 49 OFFCURVE",
+"295 49 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"344 142 OFFCURVE",
+"377 154 OFFCURVE",
+"414 177 CURVE SMOOTH",
+"448 197 OFFCURVE",
+"474 221 OFFCURVE",
+"492 247 CURVE SMOOTH",
+"495 252 OFFCURVE",
+"497 255 OFFCURVE",
+"497 258 CURVE SMOOTH",
+"497 261 OFFCURVE",
+"496 261 OFFCURVE",
+"493 261 CURVE SMOOTH",
+"488 261 OFFCURVE",
+"482 258 OFFCURVE",
+"476 250 CURVE SMOOTH",
+"433 196 OFFCURVE",
+"386 169 OFFCURVE",
+"333 169 CURVE SMOOTH",
+"292 169 OFFCURVE",
+"271 193 OFFCURVE",
+"271 243 CURVE SMOOTH",
+"271 267 OFFCURVE",
+"278 293 OFFCURVE",
+"292 317 CURVE SMOOTH",
+"309 345 OFFCURVE",
+"327 359 OFFCURVE",
+"350 359 CURVE SMOOTH",
+"369 359 OFFCURVE",
+"379 351 OFFCURVE",
+"379 335 CURVE SMOOTH",
+"379 328 OFFCURVE",
+"374 313 OFFCURVE",
+"374 308 CURVE SMOOTH",
+"375 303 OFFCURVE",
+"376 301 OFFCURVE",
+"378 301 CURVE SMOOTH",
+"383 301 OFFCURVE",
+"389 310 OFFCURVE",
+"397 328 CURVE SMOOTH",
+"406 345 OFFCURVE",
+"411 357 OFFCURVE",
+"411 364 CURVE SMOOTH",
+"411 382 OFFCURVE",
+"399 391 OFFCURVE",
+"375 391 CURVE SMOOTH",
+"344 391 OFFCURVE",
+"312 373 OFFCURVE",
+"281 336 CURVE SMOOTH",
+"251 299 OFFCURVE",
+"235 263 OFFCURVE",
+"235 231 CURVE SMOOTH",
+"235 181 OFFCURVE",
+"265 142 OFFCURVE",
+"314 142 CURVE SMOOTH"
 );
 }
 );
@@ -63690,77 +61325,491 @@ paths = (
 {
 closed = 1;
 nodes = (
-"20 342 OFFCURVE",
-"30 345 OFFCURVE",
-"30 349 CURVE SMOOTH",
-"30 350 OFFCURVE",
-"29 351 OFFCURVE",
-"26 352 CURVE SMOOTH",
-"-10 367 OFFCURVE",
-"-77 436 OFFCURVE",
-"-92 446 CURVE SMOOTH",
-"-97 450 OFFCURVE",
-"-111 452 OFFCURVE",
-"-122 452 CURVE SMOOTH",
-"-132 452 OFFCURVE",
-"-140 451 OFFCURVE",
-"-140 446 CURVE SMOOTH",
-"-139 439 OFFCURVE",
-"-137 429 OFFCURVE",
-"-106 409 CURVE SMOOTH",
-"-101 406 OFFCURVE",
-"4 346 OFFCURVE",
-"13 345 CURVE"
+"431 28 OFFCURVE",
+"610 186 OFFCURVE",
+"610 339 CURVE SMOOTH",
+"610 441 OFFCURVE",
+"526 509 OFFCURVE",
+"429 509 CURVE SMOOTH",
+"279 509 OFFCURVE",
+"97 350 OFFCURVE",
+"97 197 CURVE SMOOTH",
+"97 96 OFFCURVE",
+"186 28 OFFCURVE",
+"283 28 CURVE SMOOTH"
 );
-}
-);
-width = 0;
-}
-);
-unicode = 0300;
 },
 {
-color = 3;
-glyphname = acutecomb;
+closed = 1;
+nodes = (
+"218 49 OFFCURVE",
+"140 99 OFFCURVE",
+"133 180 CURVE SMOOTH",
+"120 329 OFFCURVE",
+"273 490 OFFCURVE",
+"421 490 CURVE SMOOTH",
+"510 490 OFFCURVE",
+"574 422 OFFCURVE",
+"574 331 CURVE SMOOTH",
+"574 194 OFFCURVE",
+"427 49 OFFCURVE",
+"295 49 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"344 142 OFFCURVE",
+"377 154 OFFCURVE",
+"414 177 CURVE SMOOTH",
+"448 197 OFFCURVE",
+"474 221 OFFCURVE",
+"492 247 CURVE SMOOTH",
+"495 252 OFFCURVE",
+"497 255 OFFCURVE",
+"497 258 CURVE SMOOTH",
+"497 261 OFFCURVE",
+"496 261 OFFCURVE",
+"493 261 CURVE SMOOTH",
+"488 261 OFFCURVE",
+"482 258 OFFCURVE",
+"476 250 CURVE SMOOTH",
+"433 196 OFFCURVE",
+"386 169 OFFCURVE",
+"333 169 CURVE SMOOTH",
+"292 169 OFFCURVE",
+"271 193 OFFCURVE",
+"271 243 CURVE SMOOTH",
+"271 267 OFFCURVE",
+"278 293 OFFCURVE",
+"292 317 CURVE SMOOTH",
+"309 345 OFFCURVE",
+"327 359 OFFCURVE",
+"350 359 CURVE SMOOTH",
+"369 359 OFFCURVE",
+"379 351 OFFCURVE",
+"379 335 CURVE SMOOTH",
+"379 328 OFFCURVE",
+"374 313 OFFCURVE",
+"374 308 CURVE SMOOTH",
+"375 303 OFFCURVE",
+"376 301 OFFCURVE",
+"378 301 CURVE SMOOTH",
+"383 301 OFFCURVE",
+"389 310 OFFCURVE",
+"397 328 CURVE SMOOTH",
+"406 345 OFFCURVE",
+"411 357 OFFCURVE",
+"411 364 CURVE SMOOTH",
+"411 382 OFFCURVE",
+"399 391 OFFCURVE",
+"375 391 CURVE SMOOTH",
+"344 391 OFFCURVE",
+"312 373 OFFCURVE",
+"281 336 CURVE SMOOTH",
+"251 299 OFFCURVE",
+"235 263 OFFCURVE",
+"235 231 CURVE SMOOTH",
+"235 181 OFFCURVE",
+"265 142 OFFCURVE",
+"314 142 CURVE SMOOTH"
+);
+}
+);
+width = 623;
+}
+);
+note = copyright;
+unicode = 00A9;
+},
+{
+glyphname = registered;
+lastChange = "2022-02-14 10:09:09 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"571 448 OFFCURVE",
+"491 509 OFFCURVE",
+"399 509 CURVE SMOOTH",
+"244 509 OFFCURVE",
+"54 339 OFFCURVE",
+"68 181 CURVE SMOOTH",
+"76 89 OFFCURVE",
+"161 28 OFFCURVE",
+"253 28 CURVE SMOOTH",
+"405 28 OFFCURVE",
+"593 198 OFFCURVE",
+"579 355 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"420 118 LINE SMOOTH",
+"379 118 OFFCURVE",
+"342 166 OFFCURVE",
+"317 255 CURVE",
+"356 256 OFFCURVE",
+"393 262 OFFCURVE",
+"428 277 CURVE SMOOTH",
+"474 296 OFFCURVE",
+"497 322 OFFCURVE",
+"497 354 CURVE SMOOTH",
+"497 381 OFFCURVE",
+"481 401 OFFCURVE",
+"448 414 CURVE SMOOTH",
+"425 423 OFFCURVE",
+"398 428 OFFCURVE",
+"366 428 CURVE SMOOTH",
+"314 428 OFFCURVE",
+"259 417 OFFCURVE",
+"201 394 CURVE SMOOTH",
+"195 391 OFFCURVE",
+"189 389 OFFCURVE",
+"185 388 CURVE",
+"241 449 OFFCURVE",
+"317 490 OFFCURVE",
+"391 490 CURVE SMOOTH",
+"474 490 OFFCURVE",
+"536 430 OFFCURVE",
+"543 347 CURVE SMOOTH",
+"551 264 OFFCURVE",
+"501 177 OFFCURVE",
+"432 118 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"169 78 OFFCURVE",
+"169 81 OFFCURVE",
+"170 85 CURVE SMOOTH",
+"175 118 OFFCURVE",
+"198 166 OFFCURVE",
+"240 227 CURVE SMOOTH",
+"261 260 OFFCURVE",
+"294 302 OFFCURVE",
+"338 358 CURVE SMOOTH",
+"359 384 OFFCURVE",
+"368 398 OFFCURVE",
+"369 400 CURVE",
+"348 411 LINE",
+"316 379 OFFCURVE",
+"278 331 OFFCURVE",
+"234 265 CURVE SMOOTH",
+"182 190 OFFCURVE",
+"156 138 OFFCURVE",
+"156 109 CURVE SMOOTH",
+"156 98 OFFCURVE",
+"157 89 OFFCURVE",
+"159 83 CURVE",
+"128 105 OFFCURVE",
+"107 139 OFFCURVE",
+"103 180 CURVE SMOOTH",
+"98 241 OFFCURVE",
+"120 304 OFFCURVE",
+"161 358 CURVE",
+"164 360 OFFCURVE",
+"168 361 OFFCURVE",
+"172 363 CURVE SMOOTH",
+"197 376 OFFCURVE",
+"228 387 OFFCURVE",
+"266 398 CURVE SMOOTH",
+"307 411 OFFCURVE",
+"339 417 OFFCURVE",
+"362 417 CURVE SMOOTH",
+"436 417 OFFCURVE",
+"473 398 OFFCURVE",
+"473 361 CURVE SMOOTH",
+"473 301 OFFCURVE",
+"363 266 OFFCURVE",
+"290 266 CURVE SMOOTH",
+"281 266 OFFCURVE",
+"283 261 OFFCURVE",
+"287 258 CURVE",
+"296 227 OFFCURVE",
+"310 197 OFFCURVE",
+"328 169 CURVE SMOOTH",
+"352 133 OFFCURVE",
+"375 111 OFFCURVE",
+"400 105 CURVE SMOOTH",
+"404 104 OFFCURVE",
+"409 103 OFFCURVE",
+"414 103 CURVE",
+"368 70 OFFCURVE",
+"316 49 OFFCURVE",
+"265 49 CURVE SMOOTH",
+"231 49 OFFCURVE",
+"197 59 OFFCURVE",
+"168 76 CURVE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"401 28 OFFCURVE",
+"580 186 OFFCURVE",
+"580 339 CURVE SMOOTH",
+"580 441 OFFCURVE",
+"496 509 OFFCURVE",
+"399 509 CURVE SMOOTH",
+"249 509 OFFCURVE",
+"67 350 OFFCURVE",
+"67 197 CURVE SMOOTH",
+"67 96 OFFCURVE",
+"156 28 OFFCURVE",
+"253 28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 49 OFFCURVE",
+"197 59 OFFCURVE",
+"168 76 CURVE",
+"169 78 OFFCURVE",
+"169 81 OFFCURVE",
+"170 85 CURVE SMOOTH",
+"175 118 OFFCURVE",
+"198 166 OFFCURVE",
+"240 227 CURVE SMOOTH",
+"261 260 OFFCURVE",
+"294 302 OFFCURVE",
+"338 358 CURVE SMOOTH",
+"359 384 OFFCURVE",
+"368 398 OFFCURVE",
+"369 400 CURVE",
+"348 411 LINE",
+"316 379 OFFCURVE",
+"278 331 OFFCURVE",
+"234 265 CURVE SMOOTH",
+"182 190 OFFCURVE",
+"156 138 OFFCURVE",
+"156 109 CURVE SMOOTH",
+"156 98 OFFCURVE",
+"157 89 OFFCURVE",
+"159 83 CURVE",
+"124 108 OFFCURVE",
+"102 147 OFFCURVE",
+"102 196 CURVE SMOOTH",
+"102 253 OFFCURVE",
+"124 309 OFFCURVE",
+"161 358 CURVE",
+"164 360 OFFCURVE",
+"168 361 OFFCURVE",
+"172 363 CURVE SMOOTH",
+"197 376 OFFCURVE",
+"228 387 OFFCURVE",
+"266 398 CURVE SMOOTH",
+"307 411 OFFCURVE",
+"339 417 OFFCURVE",
+"362 417 CURVE SMOOTH",
+"436 417 OFFCURVE",
+"473 398 OFFCURVE",
+"473 361 CURVE SMOOTH",
+"473 301 OFFCURVE",
+"363 266 OFFCURVE",
+"290 266 CURVE SMOOTH",
+"281 266 OFFCURVE",
+"283 261 OFFCURVE",
+"287 258 CURVE",
+"296 227 OFFCURVE",
+"310 197 OFFCURVE",
+"328 169 CURVE SMOOTH",
+"352 133 OFFCURVE",
+"375 111 OFFCURVE",
+"400 105 CURVE SMOOTH",
+"404 104 OFFCURVE",
+"409 103 OFFCURVE",
+"414 103 CURVE",
+"368 70 OFFCURVE",
+"316 49 OFFCURVE",
+"265 49 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 118 OFFCURVE",
+"342 166 OFFCURVE",
+"317 255 CURVE",
+"356 256 OFFCURVE",
+"393 262 OFFCURVE",
+"428 277 CURVE SMOOTH",
+"474 296 OFFCURVE",
+"497 322 OFFCURVE",
+"497 354 CURVE SMOOTH",
+"497 381 OFFCURVE",
+"481 401 OFFCURVE",
+"448 414 CURVE SMOOTH",
+"425 423 OFFCURVE",
+"398 428 OFFCURVE",
+"366 428 CURVE SMOOTH",
+"314 428 OFFCURVE",
+"259 417 OFFCURVE",
+"201 394 CURVE SMOOTH",
+"195 391 OFFCURVE",
+"189 389 OFFCURVE",
+"185 388 CURVE",
+"241 449 OFFCURVE",
+"317 490 OFFCURVE",
+"391 490 CURVE SMOOTH",
+"480 490 OFFCURVE",
+"544 422 OFFCURVE",
+"544 330 CURVE SMOOTH",
+"544 253 OFFCURVE",
+"496 173 OFFCURVE",
+"432 118 CURVE",
+"420 118 LINE SMOOTH"
+);
+}
+);
+width = 623;
+}
+);
+note = registered;
+unicode = 00AE;
+},
+{
+glyphname = trademark;
 lastChange = "2022-02-14 21:32:36 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"13 737 OFFCURVE",
-"15 737 OFFCURVE",
-"17 738 CURVE",
-"25 739 OFFCURVE",
-"131 799 OFFCURVE",
-"136 802 CURVE SMOOTH",
-"167 822 OFFCURVE",
-"169 832 OFFCURVE",
-"170 839 CURVE SMOOTH",
-"170 844 OFFCURVE",
-"162 845 OFFCURVE",
-"152 845 CURVE SMOOTH",
-"141 845 OFFCURVE",
-"127 843 OFFCURVE",
-"122 839 CURVE SMOOTH",
-"106 829 OFFCURVE",
-"40 760 OFFCURVE",
-"4 745 CURVE",
-"-5 741 OFFCURVE",
-"3 737 OFFCURVE",
-"10 737 CURVE SMOOTH"
+"369 320 OFFCURVE",
+"378 325 OFFCURVE",
+"385 336 CURVE SMOOTH",
+"395 351 OFFCURVE",
+"404 380 OFFCURVE",
+"415 420 CURVE SMOOTH",
+"427 464 OFFCURVE",
+"437 495 OFFCURVE",
+"443 509 CURVE",
+"468 422 OFFCURVE",
+"496 378 OFFCURVE",
+"530 378 CURVE SMOOTH",
+"562 378 OFFCURVE",
+"611 422 OFFCURVE",
+"680 509 CURVE",
+"665 438 OFFCURVE",
+"655 384 OFFCURVE",
+"648 348 CURVE SMOOTH",
+"647 344 OFFCURVE",
+"647 341 OFFCURVE",
+"647 341 CURVE SMOOTH",
+"647 335 OFFCURVE",
+"651 332 OFFCURVE",
+"658 332 CURVE SMOOTH",
+"675 332 OFFCURVE",
+"685 338 OFFCURVE",
+"692 348 CURVE",
+"699 407 OFFCURVE",
+"704 462 OFFCURVE",
+"706 513 CURVE",
+"707 519 OFFCURVE",
+"709 531 OFFCURVE",
+"714 549 CURVE SMOOTH",
+"717 565 OFFCURVE",
+"719 576 OFFCURVE",
+"719 582 CURVE SMOOTH",
+"719 600 OFFCURVE",
+"715 609 OFFCURVE",
+"707 609 CURVE SMOOTH",
+"706 609 OFFCURVE",
+"682 574 OFFCURVE",
+"637 503 CURVE SMOOTH",
+"592 433 OFFCURVE",
+"560 398 OFFCURVE",
+"540 398 CURVE SMOOTH",
+"518 398 OFFCURVE",
+"501 426 OFFCURVE",
+"488 482 CURVE",
+"482 520 OFFCURVE",
+"477 558 OFFCURVE",
+"470 596 CURVE SMOOTH",
+"466 611 OFFCURVE",
+"462 618 OFFCURVE",
+"457 618 CURVE SMOOTH",
+"444 618 OFFCURVE",
+"437 606 OFFCURVE",
+"434 583 CURVE SMOOTH",
+"432 568 OFFCURVE",
+"430 552 OFFCURVE",
+"429 536 CURVE",
+"426 527 OFFCURVE",
+"411 489 OFFCURVE",
+"385 423 CURVE SMOOTH",
+"361 362 OFFCURVE",
+"348 330 OFFCURVE",
+"348 327 CURVE SMOOTH",
+"348 322 OFFCURVE",
+"352 320 OFFCURVE",
+"359 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 314 OFFCURVE",
+"186 317 OFFCURVE",
+"190 323 CURVE",
+"201 349 OFFCURVE",
+"210 372 OFFCURVE",
+"215 388 CURVE SMOOTH",
+"226 421 OFFCURVE",
+"236 454 OFFCURVE",
+"245 486 CURVE SMOOTH",
+"259 528 OFFCURVE",
+"272 559 OFFCURVE",
+"282 580 CURVE SMOOTH",
+"287 588 OFFCURVE",
+"314 595 OFFCURVE",
+"361 600 CURVE SMOOTH",
+"406 605 OFFCURVE",
+"429 612 OFFCURVE",
+"429 620 CURVE SMOOTH",
+"429 624 OFFCURVE",
+"422 627 OFFCURVE",
+"407 627 CURVE SMOOTH",
+"371 627 OFFCURVE",
+"321 624 OFFCURVE",
+"258 620 CURVE SMOOTH",
+"175 614 OFFCURVE",
+"131 607 OFFCURVE",
+"126 598 CURVE",
+"129 589 OFFCURVE",
+"137 585 OFFCURVE",
+"151 585 CURVE SMOOTH",
+"166 585 OFFCURVE",
+"205 590 OFFCURVE",
+"221 590 CURVE SMOOTH",
+"240 590 OFFCURVE",
+"248 587 OFFCURVE",
+"248 582 CURVE SMOOTH",
+"248 577 OFFCURVE",
+"244 563 OFFCURVE",
+"237 541 CURVE",
+"220 503 OFFCURVE",
+"204 466 OFFCURVE",
+"189 429 CURVE SMOOTH",
+"164 370 OFFCURVE",
+"152 336 OFFCURVE",
+"152 327 CURVE SMOOTH",
+"152 318 OFFCURVE",
+"158 314 OFFCURVE",
+"169 314 CURVE SMOOTH"
 );
 }
 );
@@ -63770,103 +61819,176 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-17 344 OFFCURVE",
-"-15 344 OFFCURVE",
-"-13 345 CURVE",
-"-5 346 OFFCURVE",
-"101 406 OFFCURVE",
-"106 409 CURVE SMOOTH",
-"137 429 OFFCURVE",
-"139 439 OFFCURVE",
-"140 446 CURVE SMOOTH",
-"140 451 OFFCURVE",
-"132 452 OFFCURVE",
-"122 452 CURVE SMOOTH",
-"111 452 OFFCURVE",
-"97 450 OFFCURVE",
-"92 446 CURVE SMOOTH",
-"76 436 OFFCURVE",
-"10 367 OFFCURVE",
-"-26 352 CURVE SMOOTH",
-"-35 348 OFFCURVE",
-"-27 344 OFFCURVE",
-"-20 344 CURVE SMOOTH"
+"369 320 OFFCURVE",
+"378 325 OFFCURVE",
+"385 336 CURVE SMOOTH",
+"395 351 OFFCURVE",
+"404 380 OFFCURVE",
+"415 420 CURVE SMOOTH",
+"427 464 OFFCURVE",
+"437 495 OFFCURVE",
+"443 509 CURVE",
+"468 422 OFFCURVE",
+"496 378 OFFCURVE",
+"530 378 CURVE SMOOTH",
+"562 378 OFFCURVE",
+"611 422 OFFCURVE",
+"680 509 CURVE",
+"665 438 OFFCURVE",
+"655 384 OFFCURVE",
+"648 348 CURVE SMOOTH",
+"647 344 OFFCURVE",
+"647 341 OFFCURVE",
+"647 341 CURVE",
+"647 335 OFFCURVE",
+"651 332 OFFCURVE",
+"658 332 CURVE SMOOTH",
+"675 332 OFFCURVE",
+"685 338 OFFCURVE",
+"692 348 CURVE",
+"699 407 OFFCURVE",
+"704 462 OFFCURVE",
+"706 513 CURVE",
+"707 519 OFFCURVE",
+"709 531 OFFCURVE",
+"714 549 CURVE SMOOTH",
+"717 565 OFFCURVE",
+"719 576 OFFCURVE",
+"719 582 CURVE SMOOTH",
+"719 600 OFFCURVE",
+"715 609 OFFCURVE",
+"707 609 CURVE SMOOTH",
+"706 609 OFFCURVE",
+"682 574 OFFCURVE",
+"637 503 CURVE SMOOTH",
+"592 433 OFFCURVE",
+"560 398 OFFCURVE",
+"540 398 CURVE SMOOTH",
+"518 398 OFFCURVE",
+"501 426 OFFCURVE",
+"488 482 CURVE",
+"482 520 OFFCURVE",
+"477 558 OFFCURVE",
+"470 596 CURVE SMOOTH",
+"466 611 OFFCURVE",
+"462 618 OFFCURVE",
+"457 618 CURVE SMOOTH",
+"444 618 OFFCURVE",
+"437 606 OFFCURVE",
+"434 583 CURVE SMOOTH",
+"432 568 OFFCURVE",
+"430 552 OFFCURVE",
+"429 536 CURVE",
+"426 527 OFFCURVE",
+"411 489 OFFCURVE",
+"385 423 CURVE SMOOTH",
+"361 362 OFFCURVE",
+"348 330 OFFCURVE",
+"348 327 CURVE SMOOTH",
+"348 322 OFFCURVE",
+"352 320 OFFCURVE",
+"359 320 CURVE SMOOTH"
 );
-}
-);
-width = 0;
-}
-);
-unicode = 0301;
 },
 {
-color = 3;
-glyphname = hungarumlautcomb;
-lastChange = "2022-02-10 20:26:19 +0000";
+closed = 1;
+nodes = (
+"179 314 OFFCURVE",
+"186 317 OFFCURVE",
+"190 323 CURVE",
+"201 349 OFFCURVE",
+"210 372 OFFCURVE",
+"215 388 CURVE SMOOTH",
+"226 421 OFFCURVE",
+"236 454 OFFCURVE",
+"245 486 CURVE SMOOTH",
+"259 528 OFFCURVE",
+"272 559 OFFCURVE",
+"282 580 CURVE SMOOTH",
+"287 588 OFFCURVE",
+"314 595 OFFCURVE",
+"361 600 CURVE SMOOTH",
+"406 605 OFFCURVE",
+"429 612 OFFCURVE",
+"429 620 CURVE SMOOTH",
+"429 624 OFFCURVE",
+"422 627 OFFCURVE",
+"407 627 CURVE SMOOTH",
+"371 627 OFFCURVE",
+"321 624 OFFCURVE",
+"258 620 CURVE SMOOTH",
+"175 614 OFFCURVE",
+"131 607 OFFCURVE",
+"126 598 CURVE",
+"129 589 OFFCURVE",
+"137 585 OFFCURVE",
+"151 585 CURVE SMOOTH",
+"166 585 OFFCURVE",
+"205 590 OFFCURVE",
+"221 590 CURVE SMOOTH",
+"240 590 OFFCURVE",
+"248 587 OFFCURVE",
+"248 582 CURVE SMOOTH",
+"248 577 OFFCURVE",
+"244 563 OFFCURVE",
+"237 541 CURVE",
+"220 503 OFFCURVE",
+"204 466 OFFCURVE",
+"189 429 CURVE SMOOTH",
+"164 370 OFFCURVE",
+"152 336 OFFCURVE",
+"152 327 CURVE SMOOTH",
+"152 318 OFFCURVE",
+"158 314 OFFCURVE",
+"169 314 CURVE SMOOTH"
+);
+}
+);
+width = 721;
+}
+);
+note = trademark;
+unicode = 2122;
+},
+{
+glyphname = degree;
+lastChange = "2022-02-14 20:35:57 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"12 728 OFFCURVE",
-"17 730 OFFCURVE",
-"19 735 CURVE SMOOTH",
-"23 744 OFFCURVE",
-"61 838 OFFCURVE",
-"64 847 CURVE SMOOTH",
-"66 854 OFFCURVE",
-"55 857 OFFCURVE",
-"43 857 CURVE SMOOTH",
-"30 857 OFFCURVE",
-"18 854 OFFCURVE",
-"18 846 CURVE SMOOTH",
-"18 817 OFFCURVE",
-"12 778 OFFCURVE",
-"2 745 CURVE SMOOTH",
-"1 743 OFFCURVE",
-"1 740 OFFCURVE",
-"1 738 CURVE SMOOTH",
-"1 731 OFFCURVE",
-"4 728 OFFCURVE",
-"8 728 CURVE SMOOTH"
+"223 349 OFFCURVE",
+"263 389 OFFCURVE",
+"263 437 CURVE SMOOTH",
+"263 485 OFFCURVE",
+"223 526 OFFCURVE",
+"175 526 CURVE SMOOTH",
+"127 526 OFFCURVE",
+"87 485 OFFCURVE",
+"87 437 CURVE SMOOTH",
+"87 389 OFFCURVE",
+"127 349 OFFCURVE",
+"175 349 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"115 728 OFFCURVE",
-"120 730 OFFCURVE",
-"122 735 CURVE SMOOTH",
-"127 744 OFFCURVE",
-"165 838 OFFCURVE",
-"168 847 CURVE SMOOTH",
-"170 854 OFFCURVE",
-"158 857 OFFCURVE",
-"146 857 CURVE SMOOTH",
-"134 857 OFFCURVE",
-"121 854 OFFCURVE",
-"121 846 CURVE SMOOTH",
-"121 817 OFFCURVE",
-"115 778 OFFCURVE",
-"105 745 CURVE SMOOTH",
-"104 743 OFFCURVE",
-"104 740 OFFCURVE",
-"104 738 CURVE SMOOTH",
-"104 731 OFFCURVE",
-"107 728 OFFCURVE",
-"111 728 CURVE SMOOTH"
+"147 385 OFFCURVE",
+"123 410 OFFCURVE",
+"123 437 CURVE SMOOTH",
+"123 465 OFFCURVE",
+"147 490 OFFCURVE",
+"175 490 CURVE SMOOTH",
+"203 490 OFFCURVE",
+"227 465 OFFCURVE",
+"227 437 CURVE SMOOTH",
+"227 410 OFFCURVE",
+"203 385 OFFCURVE",
+"175 385 CURVE SMOOTH"
 );
 }
 );
@@ -63876,96 +61998,69 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-48 344 OFFCURVE",
-"-43 346 OFFCURVE",
-"-41 351 CURVE SMOOTH",
-"-37 360 OFFCURVE",
-"1 454 OFFCURVE",
-"4 463 CURVE SMOOTH",
-"6 470 OFFCURVE",
-"-5 473 OFFCURVE",
-"-17 473 CURVE SMOOTH",
-"-30 473 OFFCURVE",
-"-42 470 OFFCURVE",
-"-42 462 CURVE SMOOTH",
-"-42 433 OFFCURVE",
-"-48 394 OFFCURVE",
-"-58 361 CURVE SMOOTH",
-"-59 359 OFFCURVE",
-"-59 356 OFFCURVE",
-"-59 354 CURVE SMOOTH",
-"-59 347 OFFCURVE",
-"-56 344 OFFCURVE",
-"-52 344 CURVE SMOOTH"
+"223 349 OFFCURVE",
+"263 389 OFFCURVE",
+"263 437 CURVE SMOOTH",
+"263 485 OFFCURVE",
+"223 526 OFFCURVE",
+"175 526 CURVE SMOOTH",
+"127 526 OFFCURVE",
+"87 485 OFFCURVE",
+"87 437 CURVE SMOOTH",
+"87 389 OFFCURVE",
+"127 349 OFFCURVE",
+"175 349 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"55 344 OFFCURVE",
-"60 346 OFFCURVE",
-"62 351 CURVE SMOOTH",
-"67 360 OFFCURVE",
-"105 454 OFFCURVE",
-"108 463 CURVE SMOOTH",
-"110 470 OFFCURVE",
-"98 473 OFFCURVE",
-"86 473 CURVE SMOOTH",
-"74 473 OFFCURVE",
-"61 470 OFFCURVE",
-"61 462 CURVE SMOOTH",
-"61 433 OFFCURVE",
-"55 394 OFFCURVE",
-"45 361 CURVE SMOOTH",
-"44 359 OFFCURVE",
-"44 356 OFFCURVE",
-"44 354 CURVE SMOOTH",
-"44 347 OFFCURVE",
-"47 344 OFFCURVE",
-"51 344 CURVE SMOOTH"
+"147 385 OFFCURVE",
+"123 410 OFFCURVE",
+"123 437 CURVE SMOOTH",
+"123 465 OFFCURVE",
+"147 490 OFFCURVE",
+"175 490 CURVE SMOOTH",
+"203 490 OFFCURVE",
+"227 465 OFFCURVE",
+"227 437 CURVE SMOOTH",
+"227 410 OFFCURVE",
+"203 385 OFFCURVE",
+"175 385 CURVE SMOOTH"
 );
 }
 );
-width = 0;
+width = 285;
 }
 );
-unicode = 030B;
+note = degree;
+unicode = 00B0;
 },
 {
-color = 3;
-glyphname = caroncomb.alt;
-lastChange = "2022-02-10 20:26:17 +0000";
+glyphname = minute;
+lastChange = "2022-02-14 13:13:31 +0000";
 layers = (
 {
-anchors = (
-{
-name = _topright;
-position = "{0, 585}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"6 704 OFFCURVE",
-"16 715 OFFCURVE",
-"22 729 CURVE SMOOTH",
-"38 760 OFFCURVE",
-"65 838 OFFCURVE",
-"68 847 CURVE SMOOTH",
-"70 854 OFFCURVE",
-"59 857 OFFCURVE",
-"47 857 CURVE SMOOTH",
-"34 857 OFFCURVE",
-"21 854 OFFCURVE",
-"21 846 CURVE SMOOTH",
-"21 817 OFFCURVE",
-"14 756 OFFCURVE",
-"1 714 CURVE SMOOTH",
-"-1 707 OFFCURVE",
-"0 704 OFFCURVE",
-"2 704 CURVE SMOOTH"
+"188 712 OFFCURVE",
+"220 785 OFFCURVE",
+"220 799 CURVE SMOOTH",
+"220 813 OFFCURVE",
+"213 820 OFFCURVE",
+"204 820 CURVE SMOOTH",
+"191 820 OFFCURVE",
+"189 810 OFFCURVE",
+"188 802 CURVE SMOOTH",
+"183 777 OFFCURVE",
+"167 707 OFFCURVE",
+"152 676 CURVE SMOOTH",
+"151 675 OFFCURVE",
+"166 674 OFFCURVE",
+"168 676 CURVE SMOOTH"
 );
 }
 );
@@ -63975,82 +62070,288 @@ paths = (
 {
 closed = 1;
 nodes = (
-"6 434 OFFCURVE",
-"16 445 OFFCURVE",
-"22 459 CURVE SMOOTH",
-"38 490 OFFCURVE",
-"65 568 OFFCURVE",
-"68 577 CURVE SMOOTH",
-"70 584 OFFCURVE",
-"59 587 OFFCURVE",
-"47 587 CURVE SMOOTH",
-"34 587 OFFCURVE",
-"21 584 OFFCURVE",
-"21 576 CURVE SMOOTH",
-"21 547 OFFCURVE",
-"14 486 OFFCURVE",
-"1 444 CURVE SMOOTH",
-"-1 437 OFFCURVE",
-"0 434 OFFCURVE",
-"2 434 CURVE SMOOTH"
+"164 675 OFFCURVE",
+"167 675 OFFCURVE",
+"168 676 CURVE",
+"188 712 OFFCURVE",
+"220 785 OFFCURVE",
+"220 799 CURVE SMOOTH",
+"220 813 OFFCURVE",
+"213 820 OFFCURVE",
+"204 820 CURVE SMOOTH",
+"191 820 OFFCURVE",
+"189 810 OFFCURVE",
+"188 802 CURVE SMOOTH",
+"183 777 OFFCURVE",
+"167 707 OFFCURVE",
+"152 676 CURVE",
+"151 675 OFFCURVE",
+"156 675 OFFCURVE",
+"161 675 CURVE SMOOTH"
 );
 }
 );
-width = 0;
+width = 158;
 }
+);
+leftKerningGroup = quotes;
+rightKerningGroup = quotes;
+unicode = 2032;
+},
+{
+glyphname = second;
+lastChange = "2022-02-14 13:13:31 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"188 712 OFFCURVE",
+"220 785 OFFCURVE",
+"220 799 CURVE SMOOTH",
+"220 813 OFFCURVE",
+"213 820 OFFCURVE",
+"204 820 CURVE SMOOTH",
+"191 820 OFFCURVE",
+"189 810 OFFCURVE",
+"188 802 CURVE SMOOTH",
+"183 777 OFFCURVE",
+"167 707 OFFCURVE",
+"152 676 CURVE SMOOTH",
+"151 675 OFFCURVE",
+"166 674 OFFCURVE",
+"168 676 CURVE SMOOTH"
 );
 },
 {
-color = 3;
-glyphname = circumflexcomb;
+closed = 1;
+nodes = (
+"286 712 OFFCURVE",
+"317 785 OFFCURVE",
+"317 799 CURVE SMOOTH",
+"317 813 OFFCURVE",
+"310 820 OFFCURVE",
+"301 820 CURVE SMOOTH",
+"289 820 OFFCURVE",
+"287 810 OFFCURVE",
+"286 802 CURVE SMOOTH",
+"281 777 OFFCURVE",
+"264 707 OFFCURVE",
+"250 676 CURVE SMOOTH",
+"249 675 OFFCURVE",
+"263 674 OFFCURVE",
+"265 676 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"164 675 OFFCURVE",
+"167 675 OFFCURVE",
+"168 676 CURVE",
+"188 712 OFFCURVE",
+"220 785 OFFCURVE",
+"220 799 CURVE SMOOTH",
+"220 813 OFFCURVE",
+"213 820 OFFCURVE",
+"204 820 CURVE SMOOTH",
+"191 820 OFFCURVE",
+"189 810 OFFCURVE",
+"188 802 CURVE SMOOTH",
+"183 777 OFFCURVE",
+"167 707 OFFCURVE",
+"152 676 CURVE",
+"151 675 OFFCURVE",
+"156 675 OFFCURVE",
+"161 675 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 675 OFFCURVE",
+"264 675 OFFCURVE",
+"265 676 CURVE",
+"286 712 OFFCURVE",
+"317 785 OFFCURVE",
+"317 799 CURVE SMOOTH",
+"317 813 OFFCURVE",
+"310 820 OFFCURVE",
+"301 820 CURVE SMOOTH",
+"289 820 OFFCURVE",
+"287 810 OFFCURVE",
+"286 802 CURVE SMOOTH",
+"281 777 OFFCURVE",
+"264 707 OFFCURVE",
+"250 676 CURVE",
+"249 675 OFFCURVE",
+"254 675 OFFCURVE",
+"259 675 CURVE SMOOTH"
+);
+}
+);
+width = 255;
+}
+);
+leftKerningGroup = quotes;
+rightKerningGroup = quotes;
+unicode = 2033;
+},
+{
+glyphname = bar;
+lastChange = "2022-02-14 10:09:45 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"96 -114 OFFCURVE",
+"106 -107 OFFCURVE",
+"115 -95 CURVE SMOOTH",
+"131 -71 OFFCURVE",
+"151 35 OFFCURVE",
+"174 224 CURVE SMOOTH",
+"195 397 OFFCURVE",
+"206 513 OFFCURVE",
+"206 572 CURVE SMOOTH",
+"206 575 OFFCURVE",
+"206 580 OFFCURVE",
+"207 586 CURVE",
+"207 602 LINE SMOOTH",
+"207 665 OFFCURVE",
+"192 698 OFFCURVE",
+"162 698 CURVE SMOOTH",
+"149 698 OFFCURVE",
+"143 694 OFFCURVE",
+"143 687 CURVE SMOOTH",
+"143 678 OFFCURVE",
+"145 667 OFFCURVE",
+"148 655 CURVE SMOOTH",
+"153 638 OFFCURVE",
+"155 627 OFFCURVE",
+"156 622 CURVE SMOOTH",
+"160 592 OFFCURVE",
+"162 548 OFFCURVE",
+"162 491 CURVE SMOOTH",
+"162 350 OFFCURVE",
+"150 209 OFFCURVE",
+"126 66 CURVE SMOOTH",
+"102 -50 OFFCURVE",
+"87 -106 OFFCURVE",
+"87 -113 CURVE SMOOTH",
+"87 -114 OFFCURVE",
+"87 -114 OFFCURVE",
+"88 -114 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"96 -114 OFFCURVE",
+"106 -107 OFFCURVE",
+"115 -95 CURVE SMOOTH",
+"131 -71 OFFCURVE",
+"151 35 OFFCURVE",
+"174 224 CURVE SMOOTH",
+"195 397 OFFCURVE",
+"206 513 OFFCURVE",
+"206 572 CURVE SMOOTH",
+"206 575 OFFCURVE",
+"206 580 OFFCURVE",
+"207 586 CURVE",
+"207 602 LINE SMOOTH",
+"207 665 OFFCURVE",
+"192 698 OFFCURVE",
+"162 698 CURVE SMOOTH",
+"149 698 OFFCURVE",
+"143 694 OFFCURVE",
+"143 687 CURVE SMOOTH",
+"143 678 OFFCURVE",
+"145 667 OFFCURVE",
+"148 655 CURVE SMOOTH",
+"153 638 OFFCURVE",
+"155 627 OFFCURVE",
+"156 622 CURVE SMOOTH",
+"160 592 OFFCURVE",
+"162 548 OFFCURVE",
+"162 491 CURVE SMOOTH",
+"162 350 OFFCURVE",
+"150 209 OFFCURVE",
+"126 66 CURVE SMOOTH",
+"102 -50 OFFCURVE",
+"87 -106 OFFCURVE",
+"87 -113 CURVE SMOOTH",
+"87 -114 OFFCURVE",
+"87 -114 OFFCURVE",
+"88 -114 CURVE SMOOTH"
+);
+}
+);
+width = 245;
+}
+);
+note = bar;
+unicode = 007C;
+},
+{
+glyphname = brokenbar;
 lastChange = "2022-02-14 21:32:36 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"8 728 OFFCURVE",
-"10 729 OFFCURVE",
-"12 730 CURVE",
-"18 731 OFFCURVE",
-"113 798 OFFCURVE",
-"124 808 CURVE",
-"129 800 OFFCURVE",
-"210 731 OFFCURVE",
-"214 730 CURVE",
-"219 726 OFFCURVE",
-"227 729 OFFCURVE",
-"227 734 CURVE SMOOTH",
-"227 735 OFFCURVE",
-"226 737 OFFCURVE",
-"224 738 CURVE",
-"217 743 OFFCURVE",
-"147 841 OFFCURVE",
-"143 843 CURVE SMOOTH",
-"141 845 OFFCURVE",
-"136 846 OFFCURVE",
-"131 846 CURVE SMOOTH",
-"124 846 OFFCURVE",
-"117 845 OFFCURVE",
-"114 843 CURVE SMOOTH",
-"107 839 OFFCURVE",
-"20 747 OFFCURVE",
-"3 738 CURVE",
-"-4 733 OFFCURVE",
-"1 728 OFFCURVE",
-"7 728 CURVE SMOOTH"
+"88 -114 OFFCURVE",
+"98 -107 OFFCURVE",
+"107 -95 CURVE SMOOTH",
+"123 -71 OFFCURVE",
+"143 35 OFFCURVE",
+"166 224 CURVE SMOOTH",
+"187 397 OFFCURVE",
+"198 513 OFFCURVE",
+"198 572 CURVE SMOOTH",
+"198 575 OFFCURVE",
+"198 580 OFFCURVE",
+"199 586 CURVE",
+"199 602 LINE SMOOTH",
+"199 665 OFFCURVE",
+"184 698 OFFCURVE",
+"154 698 CURVE SMOOTH",
+"141 698 OFFCURVE",
+"135 694 OFFCURVE",
+"135 687 CURVE SMOOTH",
+"135 678 OFFCURVE",
+"137 667 OFFCURVE",
+"140 655 CURVE SMOOTH",
+"145 638 OFFCURVE",
+"147 627 OFFCURVE",
+"148 622 CURVE SMOOTH",
+"152 592 OFFCURVE",
+"154 548 OFFCURVE",
+"154 491 CURVE SMOOTH",
+"154 350 OFFCURVE",
+"142 209 OFFCURVE",
+"118 66 CURVE SMOOTH",
+"94 -50 OFFCURVE",
+"79 -106 OFFCURVE",
+"79 -113 CURVE SMOOTH",
+"79 -114 OFFCURVE",
+"79 -114 OFFCURVE",
+"80 -114 CURVE SMOOTH"
 );
 }
 );
@@ -64060,95 +62361,134 @@ paths = (
 {
 closed = 1;
 nodes = (
-"-102 344 OFFCURVE",
-"-100 345 OFFCURVE",
-"-98 346 CURVE",
-"-92 347 OFFCURVE",
-"3 414 OFFCURVE",
-"14 424 CURVE",
-"19 416 OFFCURVE",
-"100 347 OFFCURVE",
-"104 346 CURVE",
-"109 342 OFFCURVE",
-"117 345 OFFCURVE",
-"117 350 CURVE SMOOTH",
-"117 351 OFFCURVE",
-"116 353 OFFCURVE",
-"114 354 CURVE SMOOTH",
-"107 359 OFFCURVE",
-"37 457 OFFCURVE",
-"33 459 CURVE",
-"31 461 OFFCURVE",
-"26 462 OFFCURVE",
-"21 462 CURVE SMOOTH",
-"14 462 OFFCURVE",
-"7 461 OFFCURVE",
-"4 459 CURVE SMOOTH",
-"-3 455 OFFCURVE",
-"-90 363 OFFCURVE",
-"-107 354 CURVE",
-"-114 349 OFFCURVE",
-"-109 344 OFFCURVE",
-"-103 344 CURVE SMOOTH"
+"98 -112 OFFCURVE",
+"107 -106 OFFCURVE",
+"113 -96 CURVE SMOOTH",
+"119 -86 OFFCURVE",
+"131 -32 OFFCURVE",
+"146 71 CURVE SMOOTH",
+"164 173 OFFCURVE",
+"172 234 OFFCURVE",
+"172 252 CURVE SMOOTH",
+"172 258 OFFCURVE",
+"168 260 OFFCURVE",
+"159 260 CURVE SMOOTH",
+"152 260 OFFCURVE",
+"146 258 OFFCURVE",
+"144 252 CURVE",
+"142 223 OFFCURVE",
+"140 197 OFFCURVE",
+"139 173 CURVE",
+"133 123 OFFCURVE",
+"125 75 OFFCURVE",
+"115 26 CURVE SMOOTH",
+"87 -112 LINE",
+"91 -115 LINE"
 );
-}
-);
-width = 0;
-}
-);
-unicode = 0302;
 },
 {
-color = 3;
-glyphname = caroncomb;
-lastChange = "2022-02-10 20:29:45 +0000";
+closed = 1;
+nodes = (
+"172 318 OFFCURVE",
+"178 320 OFFCURVE",
+"182 328 CURVE SMOOTH",
+"192 350 OFFCURVE",
+"198 436 OFFCURVE",
+"198 596 CURVE SMOOTH",
+"198 662 OFFCURVE",
+"183 696 OFFCURVE",
+"157 696 CURVE SMOOTH",
+"144 696 OFFCURVE",
+"140 692 OFFCURVE",
+"140 683 CURVE SMOOTH",
+"140 668 OFFCURVE",
+"148 635 OFFCURVE",
+"148 626 CURVE",
+"154 594 OFFCURVE",
+"157 547 OFFCURVE",
+"157 487 CURVE SMOOTH",
+"157 451 OFFCURVE",
+"150 362 OFFCURVE",
+"150 328 CURVE SMOOTH",
+"150 320 OFFCURVE",
+"154 318 OFFCURVE",
+"162 318 CURVE SMOOTH"
+);
+}
+);
+width = 236;
+}
+);
+leftMetricsKey = bar;
+note = brokenbar;
+rightMetricsKey = bar;
+unicode = 00A6;
+},
+{
+glyphname = dagger;
+lastChange = "2022-02-14 17:04:14 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"102 728 OFFCURVE",
-"109 729 OFFCURVE",
-"112 731 CURVE SMOOTH",
-"120 734 OFFCURVE",
-"206 826 OFFCURVE",
-"223 836 CURVE",
-"230 841 OFFCURVE",
-"226 846 OFFCURVE",
-"221 846 CURVE SMOOTH",
-"220 846 OFFCURVE",
-"218 845 OFFCURVE",
-"216 844 CURVE",
-"209 843 OFFCURVE",
-"114 776 OFFCURVE",
-"102 766 CURVE",
-"98 774 OFFCURVE",
-"18 843 OFFCURVE",
-"13 844 CURVE",
-"8 848 OFFCURVE",
-"-1 845 OFFCURVE",
-"-1 840 CURVE SMOOTH",
-"-1 839 OFFCURVE",
-"0 837 OFFCURVE",
-"2 836 CURVE",
-"10 831 OFFCURVE",
-"79 733 OFFCURVE",
-"83 731 CURVE SMOOTH",
-"85 729 OFFCURVE",
-"91 728 OFFCURVE",
-"96 728 CURVE SMOOTH"
+"196 11 OFFCURVE",
+"197 12 OFFCURVE",
+"198 14 CURVE",
+"207 50 OFFCURVE",
+"212 79 OFFCURVE",
+"214 100 CURVE SMOOTH",
+"225 182 OFFCURVE",
+"236 280 OFFCURVE",
+"246 394 CURVE",
+"305 397 OFFCURVE",
+"357 398 OFFCURVE",
+"400 398 CURVE SMOOTH",
+"407 398 OFFCURVE",
+"411 400 OFFCURVE",
+"411 403 CURVE SMOOTH",
+"411 404 OFFCURVE",
+"409 405 OFFCURVE",
+"406 406 CURVE SMOOTH",
+"373 413 OFFCURVE",
+"320 417 OFFCURVE",
+"248 418 CURVE",
+"255 499 OFFCURVE",
+"258 557 OFFCURVE",
+"258 594 CURVE SMOOTH",
+"258 613 LINE",
+"256 614 LINE",
+"248 613 OFFCURVE",
+"224 600 OFFCURVE",
+"224 593 CURVE SMOOTH",
+"224 533 OFFCURVE",
+"223 474 OFFCURVE",
+"221 418 CURVE",
+"153 417 OFFCURVE",
+"102 415 OFFCURVE",
+"70 411 CURVE SMOOTH",
+"69 411 OFFCURVE",
+"68 410 OFFCURVE",
+"67 409 CURVE",
+"70 401 OFFCURVE",
+"92 386 OFFCURVE",
+"100 386 CURVE SMOOTH",
+"98 386 OFFCURVE",
+"111 387 OFFCURVE",
+"141 389 CURVE SMOOTH",
+"220 393 LINE",
+"216 334 OFFCURVE",
+"209 250 OFFCURVE",
+"200 143 CURVE SMOOTH",
+"193 54 LINE SMOOTH",
+"191 30 OFFCURVE",
+"190 18 OFFCURVE",
+"190 17 CURVE SMOOTH",
+"190 13 OFFCURVE",
+"191 11 OFFCURVE",
+"194 11 CURVE SMOOTH"
 );
 }
 );
@@ -64158,95 +62498,510 @@ paths = (
 {
 closed = 1;
 nodes = (
-"6 344 OFFCURVE",
-"13 345 OFFCURVE",
-"16 347 CURVE",
-"24 350 OFFCURVE",
-"110 442 OFFCURVE",
-"127 452 CURVE SMOOTH",
-"134 457 OFFCURVE",
-"130 462 OFFCURVE",
-"125 462 CURVE SMOOTH",
-"124 462 OFFCURVE",
-"122 461 OFFCURVE",
-"120 460 CURVE",
-"113 459 OFFCURVE",
-"18 392 OFFCURVE",
-"6 382 CURVE",
-"2 390 OFFCURVE",
-"-78 459 OFFCURVE",
-"-83 460 CURVE",
-"-88 464 OFFCURVE",
-"-97 461 OFFCURVE",
-"-97 456 CURVE SMOOTH",
-"-97 455 OFFCURVE",
-"-96 453 OFFCURVE",
-"-94 452 CURVE SMOOTH",
-"-86 447 OFFCURVE",
-"-17 349 OFFCURVE",
-"-13 347 CURVE",
-"-11 345 OFFCURVE",
-"-5 344 OFFCURVE",
-"0 344 CURVE SMOOTH"
+"196 11 OFFCURVE",
+"197 12 OFFCURVE",
+"198 14 CURVE",
+"207 50 OFFCURVE",
+"212 79 OFFCURVE",
+"214 100 CURVE SMOOTH",
+"225 182 OFFCURVE",
+"236 280 OFFCURVE",
+"246 394 CURVE",
+"305 397 OFFCURVE",
+"357 398 OFFCURVE",
+"400 398 CURVE SMOOTH",
+"407 398 OFFCURVE",
+"411 400 OFFCURVE",
+"411 403 CURVE SMOOTH",
+"411 404 OFFCURVE",
+"409 405 OFFCURVE",
+"406 406 CURVE SMOOTH",
+"373 413 OFFCURVE",
+"320 417 OFFCURVE",
+"248 418 CURVE",
+"255 499 OFFCURVE",
+"258 557 OFFCURVE",
+"258 594 CURVE SMOOTH",
+"258 613 LINE",
+"256 614 LINE",
+"248 613 OFFCURVE",
+"224 600 OFFCURVE",
+"224 593 CURVE SMOOTH",
+"224 533 OFFCURVE",
+"223 474 OFFCURVE",
+"221 418 CURVE",
+"153 417 OFFCURVE",
+"102 415 OFFCURVE",
+"70 411 CURVE SMOOTH",
+"69 411 OFFCURVE",
+"68 410 OFFCURVE",
+"67 409 CURVE",
+"70 401 OFFCURVE",
+"92 386 OFFCURVE",
+"100 386 CURVE SMOOTH",
+"141 389 LINE",
+"220 393 LINE",
+"216 334 OFFCURVE",
+"209 250 OFFCURVE",
+"200 143 CURVE SMOOTH",
+"193 54 LINE",
+"190 17 LINE SMOOTH",
+"190 13 OFFCURVE",
+"191 11 OFFCURVE",
+"194 11 CURVE SMOOTH"
 );
 }
 );
-width = 0;
+width = 387;
 }
 );
-unicode = 030C;
+leftKerningGroup = dagger;
+note = dagger;
+rightKerningGroup = dagger;
+unicode = 2020;
 },
 {
-color = 3;
-glyphname = brevecomb;
+glyphname = daggerdbl;
+lastChange = "2022-02-14 17:04:14 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"208 2 OFFCURVE",
+"209 3 OFFCURVE",
+"211 5 CURVE",
+"226 90 OFFCURVE",
+"239 165 OFFCURVE",
+"245 230 CURVE",
+"307 232 OFFCURVE",
+"361 234 OFFCURVE",
+"404 234 CURVE SMOOTH",
+"411 234 OFFCURVE",
+"416 235 OFFCURVE",
+"416 239 CURVE SMOOTH",
+"416 241 OFFCURVE",
+"414 241 OFFCURVE",
+"410 242 CURVE SMOOTH",
+"379 249 OFFCURVE",
+"323 254 OFFCURVE",
+"248 255 CURVE",
+"254 301 OFFCURVE",
+"259 346 OFFCURVE",
+"263 392 CURVE",
+"323 393 OFFCURVE",
+"376 395 OFFCURVE",
+"420 395 CURVE SMOOTH",
+"427 395 OFFCURVE",
+"431 396 OFFCURVE",
+"431 400 CURVE SMOOTH",
+"431 402 OFFCURVE",
+"430 403 OFFCURVE",
+"426 404 CURVE SMOOTH",
+"393 411 OFFCURVE",
+"339 414 OFFCURVE",
+"265 416 CURVE",
+"273 502 OFFCURVE",
+"277 562 OFFCURVE",
+"277 599 CURVE SMOOTH",
+"277 605 OFFCURVE",
+"277 609 OFFCURVE",
+"276 613 CURVE SMOOTH",
+"275 615 LINE",
+"268 615 OFFCURVE",
+"242 601 OFFCURVE",
+"242 594 CURVE SMOOTH",
+"242 535 OFFCURVE",
+"241 476 OFFCURVE",
+"238 416 CURVE",
+"165 414 OFFCURVE",
+"115 413 OFFCURVE",
+"84 409 CURVE SMOOTH",
+"83 409 OFFCURVE",
+"82 409 OFFCURVE",
+"82 407 CURVE SMOOTH",
+"83 397 OFFCURVE",
+"105 383 OFFCURVE",
+"115 383 CURVE SMOOTH",
+"130 383 OFFCURVE",
+"150 385 OFFCURVE",
+"175 386 CURVE SMOOTH",
+"207 388 OFFCURVE",
+"228 389 OFFCURVE",
+"236 390 CURVE",
+"225 255 LINE",
+"154 254 OFFCURVE",
+"101 252 OFFCURVE",
+"70 248 CURVE SMOOTH",
+"68 248 OFFCURVE",
+"68 247 OFFCURVE",
+"67 245 CURVE",
+"68 238 OFFCURVE",
+"90 223 OFFCURVE",
+"100 223 CURVE SMOOTH",
+"115 223 OFFCURVE",
+"135 224 OFFCURVE",
+"161 225 CURVE SMOOTH",
+"194 227 OFFCURVE",
+"214 228 OFFCURVE",
+"222 230 CURVE",
+"209 83 LINE SMOOTH",
+"205 35 OFFCURVE",
+"202 10 OFFCURVE",
+"202 9 CURVE SMOOTH",
+"202 5 OFFCURVE",
+"204 2 OFFCURVE",
+"207 2 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"208 2 OFFCURVE",
+"209 3 OFFCURVE",
+"211 5 CURVE",
+"226 90 OFFCURVE",
+"239 165 OFFCURVE",
+"245 230 CURVE",
+"307 232 OFFCURVE",
+"361 234 OFFCURVE",
+"404 234 CURVE SMOOTH",
+"411 234 OFFCURVE",
+"416 235 OFFCURVE",
+"416 239 CURVE SMOOTH",
+"416 241 OFFCURVE",
+"414 241 OFFCURVE",
+"410 242 CURVE SMOOTH",
+"379 249 OFFCURVE",
+"323 254 OFFCURVE",
+"248 255 CURVE",
+"254 301 OFFCURVE",
+"259 346 OFFCURVE",
+"263 392 CURVE",
+"323 393 OFFCURVE",
+"376 395 OFFCURVE",
+"420 395 CURVE SMOOTH",
+"427 395 OFFCURVE",
+"431 396 OFFCURVE",
+"431 400 CURVE SMOOTH",
+"431 402 OFFCURVE",
+"430 403 OFFCURVE",
+"426 404 CURVE SMOOTH",
+"393 411 OFFCURVE",
+"339 414 OFFCURVE",
+"265 416 CURVE",
+"273 502 OFFCURVE",
+"277 562 OFFCURVE",
+"277 599 CURVE SMOOTH",
+"277 605 OFFCURVE",
+"277 609 OFFCURVE",
+"276 613 CURVE SMOOTH",
+"275 615 LINE",
+"268 615 OFFCURVE",
+"242 601 OFFCURVE",
+"242 594 CURVE SMOOTH",
+"242 535 OFFCURVE",
+"241 476 OFFCURVE",
+"238 416 CURVE",
+"165 414 OFFCURVE",
+"115 413 OFFCURVE",
+"84 409 CURVE SMOOTH",
+"83 409 OFFCURVE",
+"82 409 OFFCURVE",
+"82 407 CURVE SMOOTH",
+"83 397 OFFCURVE",
+"105 383 OFFCURVE",
+"115 383 CURVE SMOOTH",
+"130 383 OFFCURVE",
+"150 385 OFFCURVE",
+"175 386 CURVE SMOOTH",
+"207 388 OFFCURVE",
+"228 389 OFFCURVE",
+"236 390 CURVE",
+"225 255 LINE",
+"154 254 OFFCURVE",
+"101 252 OFFCURVE",
+"70 248 CURVE SMOOTH",
+"68 248 OFFCURVE",
+"68 247 OFFCURVE",
+"67 245 CURVE",
+"68 238 OFFCURVE",
+"90 223 OFFCURVE",
+"100 223 CURVE SMOOTH",
+"115 223 OFFCURVE",
+"135 224 OFFCURVE",
+"161 225 CURVE SMOOTH",
+"194 227 OFFCURVE",
+"214 228 OFFCURVE",
+"222 230 CURVE",
+"209 83 LINE SMOOTH",
+"205 35 OFFCURVE",
+"202 10 OFFCURVE",
+"202 9 CURVE SMOOTH",
+"202 5 OFFCURVE",
+"204 2 OFFCURVE",
+"207 2 CURVE SMOOTH"
+);
+}
+);
+width = 407;
+}
+);
+leftKerningGroup = dagger;
+note = daggerdbl;
+rightKerningGroup = dagger;
+unicode = 2021;
+},
+{
+glyphname = numero;
 lastChange = "2022-02-14 21:32:36 +0000";
 layers = (
 {
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
 background = {
 paths = (
 {
 closed = 1;
 nodes = (
-"107 737 OFFCURVE",
-"184 757 OFFCURVE",
-"218 821 CURVE SMOOTH",
-"220 824 OFFCURVE",
-"221 828 OFFCURVE",
-"221 831 CURVE SMOOTH",
-"221 836 OFFCURVE",
-"218 839 OFFCURVE",
-"214 839 CURVE SMOOTH",
-"211 839 OFFCURVE",
-"208 837 OFFCURVE",
-"204 834 CURVE SMOOTH",
-"179 805 OFFCURVE",
-"129 771 OFFCURVE",
-"77 771 CURVE SMOOTH",
-"47 771 OFFCURVE",
-"22 787 OFFCURVE",
-"24 831 CURVE SMOOTH",
-"24 837 OFFCURVE",
-"20 840 OFFCURVE",
-"17 840 CURVE SMOOTH",
-"12 840 OFFCURVE",
-"5 835 OFFCURVE",
-"2 827 CURVE SMOOTH",
-"0 818 OFFCURVE",
-"0 808 OFFCURVE",
-"0 800 CURVE SMOOTH",
-"0 756 OFFCURVE",
-"24 737 OFFCURVE",
-"76 737 CURVE SMOOTH"
+"191 -75 OFFCURVE",
+"211 -72 OFFCURVE",
+"227 -67 CURVE SMOOTH",
+"347 -23 OFFCURVE",
+"430 103 OFFCURVE",
+"480 213 CURVE SMOOTH",
+"502 263 OFFCURVE",
+"524 314 OFFCURVE",
+"542 365 CURVE",
+"554 336 OFFCURVE",
+"565 306 OFFCURVE",
+"576 277 CURVE SMOOTH",
+"592 234 OFFCURVE",
+"609 191 OFFCURVE",
+"625 148 CURVE SMOOTH",
+"644 101 OFFCURVE",
+"665 42 OFFCURVE",
+"700 4 CURVE SMOOTH",
+"732 -34 OFFCURVE",
+"761 -33 OFFCURVE",
+"780 -33 CURVE SMOOTH",
+"804 -33 OFFCURVE",
+"861 -20 OFFCURVE",
+"861 13 CURVE SMOOTH",
+"861 21 OFFCURVE",
+"856 25 OFFCURVE",
+"847 25 CURVE SMOOTH",
+"838 25 OFFCURVE",
+"832 18 OFFCURVE",
+"825 10 CURVE SMOOTH",
+"817 -1 OFFCURVE",
+"807 -13 OFFCURVE",
+"791 -13 CURVE SMOOTH",
+"774 -13 OFFCURVE",
+"753 2 OFFCURVE",
+"743 21 CURVE",
+"742 25 OFFCURVE",
+"742 31 OFFCURVE",
+"742 38 CURVE SMOOTH",
+"742 141 OFFCURVE",
+"845 438 OFFCURVE",
+"898 514 CURVE SMOOTH",
+"915 538 OFFCURVE",
+"948 569 OFFCURVE",
+"977 569 CURVE SMOOTH",
+"987 569 OFFCURVE",
+"992 564 OFFCURVE",
+"997 558 CURVE SMOOTH",
+"1000 555 OFFCURVE",
+"1002 553 OFFCURVE",
+"1006 551 CURVE",
+"1007 551 LINE SMOOTH",
+"1010 551 OFFCURVE",
+"1012 553 OFFCURVE",
+"1012 555 CURVE SMOOTH",
+"1012 558 OFFCURVE",
+"1011 559 OFFCURVE",
+"1009 562 CURVE SMOOTH",
+"1008 564 OFFCURVE",
+"1008 564 OFFCURVE",
+"1008 565 CURVE",
+"1000 576 OFFCURVE",
+"981 583 OFFCURVE",
+"960 583 CURVE SMOOTH",
+"854 583 OFFCURVE",
+"786 369 OFFCURVE",
+"759 292 CURVE SMOOTH",
+"737 223 OFFCURVE",
+"715 154 OFFCURVE",
+"703 85 CURVE",
+"695 99 OFFCURVE",
+"688 114 OFFCURVE",
+"681 130 CURVE SMOOTH",
+"677 140 OFFCURVE",
+"673 150 OFFCURVE",
+"668 160 CURVE SMOOTH",
+"647 212 OFFCURVE",
+"625 263 OFFCURVE",
+"605 316 CURVE SMOOTH",
+"592 347 OFFCURVE",
+"580 378 OFFCURVE",
+"567 410 CURVE SMOOTH",
+"566 413 OFFCURVE",
+"564 418 OFFCURVE",
+"562 422 CURVE",
+"566 435 OFFCURVE",
+"573 458 OFFCURVE",
+"573 471 CURVE SMOOTH",
+"573 475 OFFCURVE",
+"567 480 OFFCURVE",
+"563 480 CURVE SMOOTH",
+"558 480 OFFCURVE",
+"551 476 OFFCURVE",
+"541 467 CURVE",
+"507 532 OFFCURVE",
+"447 602 OFFCURVE",
+"368 602 CURVE SMOOTH",
+"305 602 OFFCURVE",
+"246 553 OFFCURVE",
+"219 501 CURVE SMOOTH",
+"210 482 OFFCURVE",
+"200 462 OFFCURVE",
+"200 442 CURVE SMOOTH",
+"200 432 OFFCURVE",
+"202 423 OFFCURVE",
+"209 423 CURVE SMOOTH",
+"213 423 OFFCURVE",
+"215 426 OFFCURVE",
+"218 431 CURVE SMOOTH",
+"220 436 OFFCURVE",
+"221 440 OFFCURVE",
+"222 446 CURVE",
+"222 447 OFFCURVE",
+"222 449 OFFCURVE",
+"223 451 CURVE",
+"227 468 OFFCURVE",
+"231 486 OFFCURVE",
+"240 501 CURVE SMOOTH",
+"265 546 OFFCURVE",
+"307 572 OFFCURVE",
+"352 572 CURVE SMOOTH",
+"436 572 OFFCURVE",
+"487 496 OFFCURVE",
+"519 425 CURVE",
+"501 363 OFFCURVE",
+"474 301 OFFCURVE",
+"449 243 CURVE SMOOTH",
+"360 51 OFFCURVE",
+"264 -57 OFFCURVE",
+"174 -57 CURVE SMOOTH",
+"86 -57 OFFCURVE",
+"42 35 OFFCURVE",
+"32 111 CURVE SMOOTH",
+"31 117 OFFCURVE",
+"31 122 OFFCURVE",
+"31 128 CURVE SMOOTH",
+"31 143 LINE SMOOTH",
+"31 153 OFFCURVE",
+"29 169 OFFCURVE",
+"22 169 CURVE SMOOTH",
+"12 169 OFFCURVE",
+"6 136 OFFCURVE",
+"6 100 CURVE SMOOTH",
+"6 60 OFFCURVE",
+"14 26 OFFCURVE",
+"28 -1 CURVE SMOOTH",
+"55 -51 OFFCURVE",
+"117 -75 OFFCURVE",
+"173 -75 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"901 170 OFFCURVE",
+"921 172 OFFCURVE",
+"942 174 CURVE SMOOTH",
+"950 174 OFFCURVE",
+"958 175 OFFCURVE",
+"966 175 CURVE SMOOTH",
+"984 176 OFFCURVE",
+"1001 177 OFFCURVE",
+"1020 177 CURVE SMOOTH",
+"1027 177 OFFCURVE",
+"1030 185 OFFCURVE",
+"1030 187 CURVE SMOOTH",
+"1030 196 OFFCURVE",
+"986 201 OFFCURVE",
+"941 201 CURVE SMOOTH",
+"923 201 OFFCURVE",
+"873 202 OFFCURVE",
+"860 194 CURVE",
+"858 192 LINE",
+"857 189 OFFCURVE",
+"868 170 OFFCURVE",
+"877 170 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"959 236 OFFCURVE",
+"1028 274 OFFCURVE",
+"1048 300 CURVE SMOOTH",
+"1080 341 OFFCURVE",
+"1119 438 OFFCURVE",
+"1119 490 CURVE SMOOTH",
+"1119 499 OFFCURVE",
+"1117 505 OFFCURVE",
+"1112 510 CURVE",
+"1104 515 OFFCURVE",
+"1090 518 OFFCURVE",
+"1078 518 CURVE SMOOTH",
+"1036 518 OFFCURVE",
+"980 486 OFFCURVE",
+"956 454 CURVE SMOOTH",
+"923 409 OFFCURVE",
+"899 335 OFFCURVE",
+"899 277 CURVE SMOOTH",
+"899 258 OFFCURVE",
+"899 236 OFFCURVE",
+"927 236 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"945 263 OFFCURVE",
+"943 272 OFFCURVE",
+"943 284 CURVE SMOOTH",
+"943 340 OFFCURVE",
+"971 412 OFFCURVE",
+"998 458 CURVE",
+"1000 460 OFFCURVE",
+"1001 462 OFFCURVE",
+"1005 466 CURVE",
+"1007 471 OFFCURVE",
+"1010 476 OFFCURVE",
+"1013 479 CURVE SMOOTH",
+"1020 487 OFFCURVE",
+"1038 494 OFFCURVE",
+"1048 494 CURVE SMOOTH",
+"1053 494 OFFCURVE",
+"1063 492 OFFCURVE",
+"1067 489 CURVE",
+"1067 489 OFFCURVE",
+"1068 484 OFFCURVE",
+"1068 478 CURVE SMOOTH",
+"1068 423 OFFCURVE",
+"1036 332 OFFCURVE",
+"1003 294 CURVE SMOOTH",
+"988 276 OFFCURVE",
+"972 266 OFFCURVE",
+"947 261 CURVE"
 );
 }
 );
@@ -64256,1726 +63011,245 @@ paths = (
 {
 closed = 1;
 nodes = (
-"31 344 OFFCURVE",
-"108 364 OFFCURVE",
-"142 428 CURVE SMOOTH",
-"144 431 OFFCURVE",
-"145 435 OFFCURVE",
-"145 438 CURVE SMOOTH",
-"145 443 OFFCURVE",
-"142 446 OFFCURVE",
-"138 446 CURVE SMOOTH",
-"135 446 OFFCURVE",
-"132 444 OFFCURVE",
-"128 441 CURVE",
-"103 412 OFFCURVE",
-"53 378 OFFCURVE",
-"1 378 CURVE SMOOTH",
-"-29 378 OFFCURVE",
-"-54 394 OFFCURVE",
-"-52 438 CURVE SMOOTH",
-"-52 444 OFFCURVE",
-"-56 447 OFFCURVE",
-"-59 447 CURVE SMOOTH",
-"-64 447 OFFCURVE",
-"-71 442 OFFCURVE",
-"-74 434 CURVE SMOOTH",
-"-76 425 OFFCURVE",
-"-76 415 OFFCURVE",
-"-76 407 CURVE SMOOTH",
-"-76 363 OFFCURVE",
-"-52 344 OFFCURVE",
-"0 344 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0306;
-},
-{
-color = 3;
-glyphname = ringcomb;
-lastChange = "2022-02-10 20:30:44 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"91 726 OFFCURVE",
-"139 772 OFFCURVE",
-"141 818 CURVE SMOOTH",
-"141 842 OFFCURVE",
-"125 868 OFFCURVE",
-"98 868 CURVE SMOOTH",
-"75 868 OFFCURVE",
-"53 855 OFFCURVE",
-"38 837 CURVE",
-"21 837 OFFCURVE",
-"0 783 OFFCURVE",
-"0 761 CURVE SMOOTH",
-"0 739 OFFCURVE",
-"18 726 OFFCURVE",
-"41 726 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"42 744 OFFCURVE",
-"38 754 OFFCURVE",
-"38 764 CURVE SMOOTH",
-"39 797 OFFCURVE",
-"55 816 OFFCURVE",
-"65 827 CURVE SMOOTH",
-"68 830 OFFCURVE",
-"69 833 OFFCURVE",
-"69 834 CURVE SMOOTH",
-"69 838 OFFCURVE",
-"63 837 OFFCURVE",
-"62 838 CURVE",
-"72 844 OFFCURVE",
-"82 851 OFFCURVE",
-"94 851 CURVE SMOOTH",
-"112 851 OFFCURVE",
-"115 829 OFFCURVE",
-"115 816 CURVE SMOOTH",
-"114 786 OFFCURVE",
-"89 744 OFFCURVE",
-"54 744 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"50 344 OFFCURVE",
-"98 390 OFFCURVE",
-"100 436 CURVE SMOOTH",
-"100 460 OFFCURVE",
-"84 486 OFFCURVE",
-"57 486 CURVE SMOOTH",
-"34 486 OFFCURVE",
-"12 473 OFFCURVE",
-"-3 455 CURVE",
-"-20 455 OFFCURVE",
-"-41 401 OFFCURVE",
-"-41 379 CURVE SMOOTH",
-"-41 357 OFFCURVE",
-"-23 344 OFFCURVE",
-"0 344 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"1 362 OFFCURVE",
-"-3 372 OFFCURVE",
-"-3 382 CURVE SMOOTH",
-"-2 415 OFFCURVE",
-"14 434 OFFCURVE",
-"24 445 CURVE SMOOTH",
-"27 448 OFFCURVE",
-"28 451 OFFCURVE",
-"28 452 CURVE SMOOTH",
-"28 456 OFFCURVE",
-"22 455 OFFCURVE",
-"21 456 CURVE",
-"31 462 OFFCURVE",
-"41 469 OFFCURVE",
-"53 469 CURVE SMOOTH",
-"71 469 OFFCURVE",
-"74 447 OFFCURVE",
-"74 434 CURVE SMOOTH",
-"73 404 OFFCURVE",
-"48 362 OFFCURVE",
-"13 362 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 030A;
-},
-{
-color = 8;
-glyphname = ringcomb_acutecomb;
-lastChange = "2022-02-14 21:30:41 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = ringcomb;
-},
-{
-name = acutecomb;
-transform = "{1, 0, 0, 1, 68, 156}";
-}
-);
-};
-components = (
-{
-name = ringcomb;
-},
-{
-alignment = -1;
-name = acutecomb;
-transform = "{1, 0, 0, 1, 110, 90}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = tildecomb;
-lastChange = "2022-02-10 20:31:45 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"179 766 OFFCURVE",
-"205 788 OFFCURVE",
-"213 821 CURVE SMOOTH",
-"213 825 OFFCURVE",
-"212 825 OFFCURVE",
-"204 825 CURVE",
-"201 814 OFFCURVE",
-"181 798 OFFCURVE",
-"158 798 CURVE SMOOTH",
-"132 798 OFFCURVE",
-"94 826 OFFCURVE",
-"63 826 CURVE SMOOTH",
-"33 826 OFFCURVE",
-"7 804 OFFCURVE",
-"0 772 CURVE SMOOTH",
-"-1 767 OFFCURVE",
-"2 767 OFFCURVE",
-"7 767 CURVE",
-"11 779 OFFCURVE",
-"30 794 OFFCURVE",
-"54 794 CURVE SMOOTH",
-"80 794 OFFCURVE",
-"118 766 OFFCURVE",
-"148 766 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"73 344 OFFCURVE",
-"99 366 OFFCURVE",
-"107 399 CURVE",
-"107 403 OFFCURVE",
-"106 403 OFFCURVE",
-"98 403 CURVE",
-"95 392 OFFCURVE",
-"75 376 OFFCURVE",
-"52 376 CURVE SMOOTH",
-"26 376 OFFCURVE",
-"-12 404 OFFCURVE",
-"-43 404 CURVE SMOOTH",
-"-73 404 OFFCURVE",
-"-99 382 OFFCURVE",
-"-106 350 CURVE SMOOTH",
-"-107 345 OFFCURVE",
-"-104 345 OFFCURVE",
-"-99 345 CURVE",
-"-95 357 OFFCURVE",
-"-76 372 OFFCURVE",
-"-52 372 CURVE SMOOTH",
-"-26 372 OFFCURVE",
-"12 344 OFFCURVE",
-"42 344 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0303;
-},
-{
-color = 3;
-glyphname = tildecomb_dotaccentcomb;
-lastChange = "2022-02-10 20:33:47 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = tildecomb;
-},
-{
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 104, 120}";
-}
-);
-};
-components = (
-{
-name = tildecomb;
-},
-{
-alignment = -1;
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 0, 90}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = tildecomb_macroncomb;
-lastChange = "2022-02-10 20:34:31 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-}
-);
-background = {
-components = (
-{
-name = tildecomb;
-},
-{
-name = macroncomb;
-transform = "{1, 0, 0, 1, 17, 87}";
-}
-);
-};
-components = (
-{
-name = tildecomb;
-},
-{
-alignment = -1;
-name = macroncomb;
-transform = "{1, 0, 0, 1, 0, 80}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-},
-{
-color = 3;
-glyphname = macroncomb;
-lastChange = "2022-02-10 20:34:34 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"51 783 OFFCURVE",
-"78 786 OFFCURVE",
-"105 788 CURVE SMOOTH",
-"138 790 OFFCURVE",
-"171 792 OFFCURVE",
-"205 792 CURVE SMOOTH",
-"213 792 OFFCURVE",
-"216 801 OFFCURVE",
-"216 804 CURVE SMOOTH",
-"216 815 OFFCURVE",
-"130 819 OFFCURVE",
-"102 819 CURVE SMOOTH",
-"81 819 OFFCURVE",
-"19 820 OFFCURVE",
-"2 811 CURVE SMOOTH",
-"0 810 LINE",
-"1 802 OFFCURVE",
-"15 783 OFFCURVE",
-"21 783 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-57 359 OFFCURVE",
-"-30 362 OFFCURVE",
-"-3 364 CURVE SMOOTH",
-"30 366 OFFCURVE",
-"63 368 OFFCURVE",
-"97 368 CURVE SMOOTH",
-"105 368 OFFCURVE",
-"108 377 OFFCURVE",
-"108 380 CURVE SMOOTH",
-"108 391 OFFCURVE",
-"22 395 OFFCURVE",
-"-6 395 CURVE SMOOTH",
-"-27 395 OFFCURVE",
-"-89 396 OFFCURVE",
-"-106 387 CURVE SMOOTH",
-"-108 386 LINE",
-"-107 378 OFFCURVE",
-"-93 359 OFFCURVE",
-"-87 359 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0304;
-},
-{
-color = 3;
-glyphname = hookabovecomb;
-lastChange = "2022-02-10 20:34:58 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"20 733 OFFCURVE",
-"33 735 OFFCURVE",
-"33 739 CURVE",
-"37 751 OFFCURVE",
-"52 767 OFFCURVE",
-"73 783 CURVE SMOOTH",
-"99 801 OFFCURVE",
-"129 822 OFFCURVE",
-"129 849 CURVE SMOOTH",
-"129 878 OFFCURVE",
-"101 886 OFFCURVE",
-"74 886 CURVE SMOOTH",
-"50 886 OFFCURVE",
-"1 872 OFFCURVE",
-"0 857 CURVE SMOOTH",
-"-1 853 OFFCURVE",
-"1 850 OFFCURVE",
-"7 850 CURVE SMOOTH",
-"15 850 OFFCURVE",
-"38 864 OFFCURVE",
-"62 864 CURVE SMOOTH",
-"77 864 OFFCURVE",
-"87 857 OFFCURVE",
-"87 847 CURVE SMOOTH",
-"87 833 OFFCURVE",
-"71 813 OFFCURVE",
-"52 796 CURVE SMOOTH",
-"34 781 OFFCURVE",
-"13 765 OFFCURVE",
-"10 739 CURVE",
-"10 735 OFFCURVE",
-"12 733 OFFCURVE",
-"17 733 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-2 343 OFFCURVE",
-"11 345 OFFCURVE",
-"11 349 CURVE",
-"15 361 OFFCURVE",
-"30 377 OFFCURVE",
-"51 393 CURVE SMOOTH",
-"77 411 OFFCURVE",
-"107 432 OFFCURVE",
-"107 459 CURVE SMOOTH",
-"107 488 OFFCURVE",
-"79 496 OFFCURVE",
-"52 496 CURVE SMOOTH",
-"28 496 OFFCURVE",
-"-21 482 OFFCURVE",
-"-22 467 CURVE",
-"-23 463 OFFCURVE",
-"-21 460 OFFCURVE",
-"-15 460 CURVE SMOOTH",
-"-7 460 OFFCURVE",
-"16 474 OFFCURVE",
-"40 474 CURVE SMOOTH",
-"55 474 OFFCURVE",
-"65 467 OFFCURVE",
-"65 457 CURVE SMOOTH",
-"65 443 OFFCURVE",
-"49 423 OFFCURVE",
-"30 406 CURVE SMOOTH",
-"12 391 OFFCURVE",
-"-9 375 OFFCURVE",
-"-12 349 CURVE SMOOTH",
-"-12 345 OFFCURVE",
-"-10 343 OFFCURVE",
-"-5 343 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0309;
-},
-{
-color = 3;
-glyphname = dblgravecomb;
-lastChange = "2022-02-11 08:38:58 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"160 735 OFFCURVE",
-"170 738 OFFCURVE",
-"170 742 CURVE SMOOTH",
-"170 743 OFFCURVE",
-"169 744 OFFCURVE",
-"166 745 CURVE",
-"130 760 OFFCURVE",
-"63 829 OFFCURVE",
-"48 839 CURVE SMOOTH",
-"43 843 OFFCURVE",
-"29 845 OFFCURVE",
-"18 845 CURVE SMOOTH",
-"8 845 OFFCURVE",
-"0 844 OFFCURVE",
-"0 839 CURVE SMOOTH",
-"1 832 OFFCURVE",
-"3 822 OFFCURVE",
-"34 802 CURVE SMOOTH",
-"39 799 OFFCURVE",
-"144 739 OFFCURVE",
-"153 738 CURVE"
+"191 -75 OFFCURVE",
+"211 -72 OFFCURVE",
+"227 -67 CURVE SMOOTH",
+"347 -23 OFFCURVE",
+"430 103 OFFCURVE",
+"480 213 CURVE SMOOTH",
+"502 263 OFFCURVE",
+"524 314 OFFCURVE",
+"542 365 CURVE",
+"554 336 OFFCURVE",
+"565 306 OFFCURVE",
+"576 277 CURVE SMOOTH",
+"625 148 LINE SMOOTH",
+"644 101 OFFCURVE",
+"665 42 OFFCURVE",
+"700 4 CURVE SMOOTH",
+"730 -32 OFFCURVE",
+"758 -33 OFFCURVE",
+"777 -33 CURVE SMOOTH",
+"799 -33 OFFCURVE",
+"861 -20 OFFCURVE",
+"861 13 CURVE SMOOTH",
+"861 21 OFFCURVE",
+"856 25 OFFCURVE",
+"847 25 CURVE SMOOTH",
+"838 25 OFFCURVE",
+"832 18 OFFCURVE",
+"825 10 CURVE SMOOTH",
+"817 -1 OFFCURVE",
+"807 -13 OFFCURVE",
+"791 -13 CURVE SMOOTH",
+"774 -13 OFFCURVE",
+"753 2 OFFCURVE",
+"743 21 CURVE",
+"742 25 OFFCURVE",
+"742 31 OFFCURVE",
+"742 38 CURVE SMOOTH",
+"742 141 OFFCURVE",
+"845 438 OFFCURVE",
+"898 514 CURVE SMOOTH",
+"915 538 OFFCURVE",
+"948 569 OFFCURVE",
+"977 569 CURVE SMOOTH",
+"987 569 OFFCURVE",
+"992 564 OFFCURVE",
+"997 558 CURVE SMOOTH",
+"1000 555 OFFCURVE",
+"1002 553 OFFCURVE",
+"1006 551 CURVE",
+"1007 551 LINE SMOOTH",
+"1010 551 OFFCURVE",
+"1012 553 OFFCURVE",
+"1012 555 CURVE SMOOTH",
+"1012 558 OFFCURVE",
+"1011 559 OFFCURVE",
+"1009 562 CURVE SMOOTH",
+"1008 564 OFFCURVE",
+"1008 564 OFFCURVE",
+"1008 565 CURVE",
+"1000 576 OFFCURVE",
+"981 583 OFFCURVE",
+"960 583 CURVE SMOOTH",
+"854 583 OFFCURVE",
+"786 369 OFFCURVE",
+"759 292 CURVE SMOOTH",
+"737 223 OFFCURVE",
+"715 154 OFFCURVE",
+"703 85 CURVE",
+"695 99 OFFCURVE",
+"688 114 OFFCURVE",
+"681 130 CURVE SMOOTH",
+"677 140 OFFCURVE",
+"673 150 OFFCURVE",
+"668 160 CURVE SMOOTH",
+"647 212 OFFCURVE",
+"625 263 OFFCURVE",
+"605 316 CURVE SMOOTH",
+"592 347 OFFCURVE",
+"580 378 OFFCURVE",
+"567 410 CURVE SMOOTH",
+"566 413 OFFCURVE",
+"564 418 OFFCURVE",
+"562 422 CURVE",
+"566 435 OFFCURVE",
+"573 458 OFFCURVE",
+"573 471 CURVE SMOOTH",
+"573 475 OFFCURVE",
+"567 480 OFFCURVE",
+"563 480 CURVE SMOOTH",
+"558 480 OFFCURVE",
+"551 476 OFFCURVE",
+"541 467 CURVE",
+"507 532 OFFCURVE",
+"447 602 OFFCURVE",
+"368 602 CURVE SMOOTH",
+"305 602 OFFCURVE",
+"246 553 OFFCURVE",
+"219 501 CURVE SMOOTH",
+"210 482 OFFCURVE",
+"200 462 OFFCURVE",
+"200 442 CURVE SMOOTH",
+"200 432 OFFCURVE",
+"202 423 OFFCURVE",
+"209 423 CURVE SMOOTH",
+"213 423 OFFCURVE",
+"215 426 OFFCURVE",
+"218 431 CURVE SMOOTH",
+"220 436 OFFCURVE",
+"221 440 OFFCURVE",
+"222 446 CURVE SMOOTH",
+"222 447 OFFCURVE",
+"222 449 OFFCURVE",
+"223 451 CURVE",
+"227 468 OFFCURVE",
+"231 486 OFFCURVE",
+"240 501 CURVE SMOOTH",
+"265 546 OFFCURVE",
+"307 572 OFFCURVE",
+"352 572 CURVE SMOOTH",
+"436 572 OFFCURVE",
+"487 496 OFFCURVE",
+"519 425 CURVE",
+"501 363 OFFCURVE",
+"474 301 OFFCURVE",
+"449 243 CURVE SMOOTH",
+"360 51 OFFCURVE",
+"264 -57 OFFCURVE",
+"174 -57 CURVE SMOOTH",
+"86 -57 OFFCURVE",
+"42 35 OFFCURVE",
+"32 111 CURVE SMOOTH",
+"31 117 OFFCURVE",
+"31 122 OFFCURVE",
+"31 128 CURVE SMOOTH",
+"31 143 LINE SMOOTH",
+"31 153 OFFCURVE",
+"29 169 OFFCURVE",
+"22 169 CURVE SMOOTH",
+"12 169 OFFCURVE",
+"6 136 OFFCURVE",
+"6 100 CURVE SMOOTH",
+"6 60 OFFCURVE",
+"14 26 OFFCURVE",
+"28 -1 CURVE SMOOTH",
+"55 -51 OFFCURVE",
+"117 -75 OFFCURVE",
+"173 -75 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"269 727 OFFCURVE",
-"273 729 OFFCURVE",
-"273 732 CURVE SMOOTH",
-"273 733 OFFCURVE",
-"272 734 OFFCURVE",
-"270 736 CURVE",
-"238 754 OFFCURVE",
-"186 828 OFFCURVE",
-"172 838 CURVE SMOOTH",
-"167 843 OFFCURVE",
-"149 848 OFFCURVE",
-"138 848 CURVE SMOOTH",
-"132 848 OFFCURVE",
-"128 847 OFFCURVE",
-"127 844 CURVE SMOOTH",
-"127 837 OFFCURVE",
-"127 827 OFFCURVE",
-"153 805 CURVE SMOOTH",
-"158 802 OFFCURVE",
-"249 732 OFFCURVE",
-"258 730 CURVE",
-"260 728 OFFCURVE",
-"262 727 OFFCURVE",
-"265 727 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-57 344 OFFCURVE",
-"-55 344 OFFCURVE",
-"-53 344 CURVE SMOOTH",
-"-47 344 OFFCURVE",
-"-42 346 OFFCURVE",
-"-42 349 CURVE SMOOTH",
-"-42 350 OFFCURVE",
-"-43 351 OFFCURVE",
-"-46 352 CURVE SMOOTH",
-"-82 367 OFFCURVE",
-"-149 436 OFFCURVE",
-"-164 446 CURVE SMOOTH",
-"-169 450 OFFCURVE",
-"-183 452 OFFCURVE",
-"-194 452 CURVE SMOOTH",
-"-204 452 OFFCURVE",
-"-212 451 OFFCURVE",
-"-212 446 CURVE SMOOTH",
-"-211 439 OFFCURVE",
-"-209 429 OFFCURVE",
-"-178 409 CURVE SMOOTH",
-"-173 406 OFFCURVE",
-"-68 346 OFFCURVE",
-"-59 345 CURVE"
+"901 170 OFFCURVE",
+"921 172 OFFCURVE",
+"942 174 CURVE SMOOTH",
+"950 174 OFFCURVE",
+"958 175 OFFCURVE",
+"966 175 CURVE SMOOTH",
+"984 176 OFFCURVE",
+"1001 177 OFFCURVE",
+"1020 177 CURVE SMOOTH",
+"1027 177 OFFCURVE",
+"1030 185 OFFCURVE",
+"1030 187 CURVE SMOOTH",
+"1030 197 OFFCURVE",
+"977 201 OFFCURVE",
+"927 201 CURVE SMOOTH",
+"904 201 OFFCURVE",
+"870 200 OFFCURVE",
+"860 194 CURVE",
+"858 192 LINE",
+"857 189 OFFCURVE",
+"868 170 OFFCURVE",
+"877 170 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"57 334 OFFCURVE",
-"61 336 OFFCURVE",
-"61 339 CURVE SMOOTH",
-"61 340 OFFCURVE",
-"60 341 OFFCURVE",
-"58 343 CURVE",
-"26 361 OFFCURVE",
-"-26 435 OFFCURVE",
-"-40 445 CURVE",
-"-45 450 OFFCURVE",
-"-63 455 OFFCURVE",
-"-74 455 CURVE SMOOTH",
-"-80 455 OFFCURVE",
-"-84 454 OFFCURVE",
-"-85 451 CURVE",
-"-85 444 OFFCURVE",
-"-85 434 OFFCURVE",
-"-59 412 CURVE",
-"-54 409 OFFCURVE",
-"37 339 OFFCURVE",
-"46 337 CURVE",
-"48 335 OFFCURVE",
-"50 334 OFFCURVE",
-"53 334 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 030F;
-},
-{
-color = 3;
-glyphname = breveinvertedcomb;
-lastChange = "2022-02-11 08:39:49 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"209 737 OFFCURVE",
-"216 742 OFFCURVE",
-"219 749 CURVE SMOOTH",
-"221 759 OFFCURVE",
-"221 769 OFFCURVE",
-"221 777 CURVE SMOOTH",
-"221 821 OFFCURVE",
-"174 840 OFFCURVE",
-"144 840 CURVE SMOOTH",
-"113 840 OFFCURVE",
-"36 820 OFFCURVE",
-"3 756 CURVE SMOOTH",
-"1 752 OFFCURVE",
-"0 748 OFFCURVE",
-"0 745 CURVE SMOOTH",
-"0 741 OFFCURVE",
-"3 738 OFFCURVE",
-"7 738 CURVE SMOOTH",
-"10 738 OFFCURVE",
-"13 740 OFFCURVE",
-"17 743 CURVE SMOOTH",
-"42 772 OFFCURVE",
-"92 806 OFFCURVE",
-"143 806 CURVE SMOOTH",
-"174 806 OFFCURVE",
-"198 789 OFFCURVE",
-"196 745 CURVE SMOOTH",
-"196 740 OFFCURVE",
-"200 737 OFFCURVE",
-"204 737 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"106 344 OFFCURVE",
-"113 349 OFFCURVE",
-"116 356 CURVE",
-"118 366 OFFCURVE",
-"118 376 OFFCURVE",
-"118 384 CURVE SMOOTH",
-"118 428 OFFCURVE",
-"71 447 OFFCURVE",
-"41 447 CURVE SMOOTH",
-"10 447 OFFCURVE",
-"-67 427 OFFCURVE",
-"-100 363 CURVE SMOOTH",
-"-102 359 OFFCURVE",
-"-103 355 OFFCURVE",
-"-103 352 CURVE SMOOTH",
-"-103 348 OFFCURVE",
-"-100 345 OFFCURVE",
-"-96 345 CURVE SMOOTH",
-"-93 345 OFFCURVE",
-"-90 347 OFFCURVE",
-"-86 350 CURVE",
-"-61 379 OFFCURVE",
-"-11 413 OFFCURVE",
-"40 413 CURVE SMOOTH",
-"71 413 OFFCURVE",
-"95 396 OFFCURVE",
-"93 352 CURVE SMOOTH",
-"93 347 OFFCURVE",
-"97 344 OFFCURVE",
-"101 344 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0311;
-},
-{
-color = 3;
-glyphname = commaturnedabovecomb;
-lastChange = "2022-02-11 08:40:41 +0000";
-layers = (
-{
-anchors = (
-{
-name = _top;
-position = "{0, 244}";
-},
-{
-name = top;
-position = "{0, 384}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"46 706 OFFCURVE",
-"46 723 OFFCURVE",
-"46 732 CURVE SMOOTH",
-"46 742 OFFCURVE",
-"40 749 OFFCURVE",
-"40 760 CURVE SMOOTH",
-"40 818 OFFCURVE",
-"81 863 OFFCURVE",
-"81 870 CURVE",
-"78 870 OFFCURVE",
-"69 870 OFFCURVE",
-"68 870 CURVE SMOOTH",
-"55 870 OFFCURVE",
-"31 823 OFFCURVE",
-"9 774 CURVE SMOOTH",
-"4 761 OFFCURVE",
-"0 748 OFFCURVE",
-"0 735 CURVE SMOOTH",
-"0 717 OFFCURVE",
-"13 706 OFFCURVE",
-"26 706 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"22 344 OFFCURVE",
-"22 361 OFFCURVE",
-"22 370 CURVE SMOOTH",
-"22 380 OFFCURVE",
-"16 387 OFFCURVE",
-"16 398 CURVE SMOOTH",
-"16 456 OFFCURVE",
-"57 501 OFFCURVE",
-"57 508 CURVE",
-"44 508 LINE SMOOTH",
-"31 508 OFFCURVE",
-"7 461 OFFCURVE",
-"-15 412 CURVE SMOOTH",
-"-20 399 OFFCURVE",
-"-24 386 OFFCURVE",
-"-24 373 CURVE SMOOTH",
-"-24 355 OFFCURVE",
-"-11 344 OFFCURVE",
-"2 344 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0312;
-},
-{
-color = 3;
-glyphname = horncomb;
-lastChange = "2022-02-11 08:44:37 +0000";
-layers = (
-{
-anchors = (
-{
-name = _horn;
-position = "{0, 244}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"68 727 OFFCURVE",
-"100 774 OFFCURVE",
-"106 825 CURVE SMOOTH",
-"107 831 OFFCURVE",
-"99 835 OFFCURVE",
-"90 835 CURVE SMOOTH",
-"80 835 OFFCURVE",
-"70 831 OFFCURVE",
-"69 824 CURVE SMOOTH",
-"62 773 OFFCURVE",
-"47 743 OFFCURVE",
-"0 743 CURVE",
-"-1 734 OFFCURVE",
-"6 727 OFFCURVE",
-"18 727 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"68 228 OFFCURVE",
-"100 275 OFFCURVE",
-"106 326 CURVE SMOOTH",
-"107 332 OFFCURVE",
-"99 336 OFFCURVE",
-"90 336 CURVE SMOOTH",
-"80 336 OFFCURVE",
-"70 332 OFFCURVE",
-"69 325 CURVE SMOOTH",
-"62 274 OFFCURVE",
-"47 244 OFFCURVE",
-"0 244 CURVE",
-"-1 235 OFFCURVE",
-"6 228 OFFCURVE",
-"18 228 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 031B;
-},
-{
-color = 3;
-glyphname = dotbelowcomb;
-lastChange = "2022-02-11 09:26:05 +0000";
-layers = (
-{
-anchors = (
-{
-name = _bottom;
-position = "{0, 0}";
-},
-{
-name = bottom;
-position = "{0, -140}";
-}
-);
-background = {
-components = (
-{
-name = dotaccentcomb;
-transform = "{1, 0, 0, 1, 0, -1000}";
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"0 -164 OFFCURVE",
-"15 -159 OFFCURVE",
-"22 -147 CURVE SMOOTH",
-"28 -136 OFFCURVE",
-"32 -125 OFFCURVE",
-"32 -119 CURVE SMOOTH",
-"32 -107 OFFCURVE",
-"25 -100 OFFCURVE",
-"7 -100 CURVE SMOOTH",
-"-12 -100 OFFCURVE",
-"-32 -121 OFFCURVE",
-"-32 -146 CURVE SMOOTH",
-"-32 -149 OFFCURVE",
-"-32 -152 OFFCURVE",
-"-31 -155 CURVE SMOOTH",
-"-30 -161 OFFCURVE",
-"-21 -164 OFFCURVE",
-"-12 -164 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0323;
-},
-{
-color = 3;
-glyphname = dieresisbelowcomb;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-anchors = (
-{
-name = _bottom;
-position = "{0, 0}";
-},
-{
-name = bottom;
-position = "{0, -140}";
-}
-);
-background = {
-components = (
-{
-name = dieresiscomb;
-transform = "{1, 0, 0, 1, 0, -1000}";
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"65 -176 OFFCURVE",
-"75 -156 OFFCURVE",
-"79 -144 CURVE",
-"81 -132 OFFCURVE",
-"91 -123 OFFCURVE",
-"102 -107 CURVE",
-"102 -103 LINE",
-"101 -100 OFFCURVE",
-"98 -100 OFFCURVE",
-"97 -100 CURVE SMOOTH",
-"82 -100 OFFCURVE",
-"29 -125 OFFCURVE",
-"29 -146 CURVE SMOOTH",
-"29 -155 OFFCURVE",
-"39 -176 OFFCURVE",
-"49 -176 CURVE SMOOTH"
+"959 236 OFFCURVE",
+"1028 274 OFFCURVE",
+"1048 300 CURVE SMOOTH",
+"1080 341 OFFCURVE",
+"1119 438 OFFCURVE",
+"1119 490 CURVE SMOOTH",
+"1119 499 OFFCURVE",
+"1117 505 OFFCURVE",
+"1112 510 CURVE",
+"1104 515 OFFCURVE",
+"1090 518 OFFCURVE",
+"1078 518 CURVE SMOOTH",
+"1036 518 OFFCURVE",
+"980 486 OFFCURVE",
+"956 454 CURVE SMOOTH",
+"923 409 OFFCURVE",
+"899 335 OFFCURVE",
+"899 277 CURVE SMOOTH",
+"899 258 OFFCURVE",
+"899 236 OFFCURVE",
+"927 236 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"-66 -176 OFFCURVE",
-"-56 -156 OFFCURVE",
-"-52 -144 CURVE SMOOTH",
-"-49 -132 OFFCURVE",
-"-40 -123 OFFCURVE",
-"-29 -107 CURVE",
-"-29 -103 LINE",
-"-30 -100 OFFCURVE",
-"-33 -100 OFFCURVE",
-"-34 -100 CURVE SMOOTH",
-"-48 -100 OFFCURVE",
-"-102 -125 OFFCURVE",
-"-102 -146 CURVE SMOOTH",
-"-102 -155 OFFCURVE",
-"-92 -176 OFFCURVE",
-"-82 -176 CURVE SMOOTH"
+"945 263 OFFCURVE",
+"943 272 OFFCURVE",
+"943 284 CURVE SMOOTH",
+"943 340 OFFCURVE",
+"971 412 OFFCURVE",
+"998 458 CURVE",
+"1000 460 OFFCURVE",
+"1001 462 OFFCURVE",
+"1005 466 CURVE",
+"1007 471 OFFCURVE",
+"1010 476 OFFCURVE",
+"1013 479 CURVE SMOOTH",
+"1020 487 OFFCURVE",
+"1038 494 OFFCURVE",
+"1048 494 CURVE SMOOTH",
+"1053 494 OFFCURVE",
+"1063 492 OFFCURVE",
+"1067 489 CURVE",
+"1067 489 OFFCURVE",
+"1068 484 OFFCURVE",
+"1068 478 CURVE SMOOTH",
+"1068 423 OFFCURVE",
+"1036 332 OFFCURVE",
+"1003 294 CURVE SMOOTH",
+"988 276 OFFCURVE",
+"972 266 OFFCURVE",
+"947 261 CURVE"
 );
 }
 );
-width = 0;
+width = 1068;
 }
 );
-unicode = 0324;
-},
-{
-color = 3;
-glyphname = commaaccentcomb;
-lastChange = "2022-02-11 10:52:10 +0000";
-layers = (
-{
-anchors = (
-{
-name = _bottom;
-position = "{0, 0}";
-},
-{
-name = bottom;
-position = "{0, -140}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"-58 -291 OFFCURVE",
-"-35 -264 OFFCURVE",
-"-1 -208 CURVE SMOOTH",
-"17 -176 OFFCURVE",
-"27 -151 OFFCURVE",
-"27 -132 CURVE SMOOTH",
-"27 -126 OFFCURVE",
-"26 -121 OFFCURVE",
-"25 -116 CURVE SMOOTH",
-"25 -117 LINE",
-"16 -105 OFFCURVE",
-"8 -99 OFFCURVE",
-"1 -99 CURVE SMOOTH",
-"-10 -99 OFFCURVE",
-"-19 -118 OFFCURVE",
-"-19 -129 CURVE SMOOTH",
-"-19 -136 OFFCURVE",
-"-13 -151 OFFCURVE",
-"-13 -157 CURVE SMOOTH",
-"-13 -181 OFFCURVE",
-"-23 -209 OFFCURVE",
-"-41 -242 CURVE SMOOTH",
-"-60 -275 OFFCURVE",
-"-70 -291 OFFCURVE",
-"-70 -290 CURVE",
-"-70 -291 OFFCURVE",
-"-70 -291 OFFCURVE",
-"-69 -291 CURVE SMOOTH"
-);
-},
-{
-closed = 1;
-nodes = (
-"22 344 OFFCURVE",
-"22 361 OFFCURVE",
-"22 370 CURVE SMOOTH",
-"22 380 OFFCURVE",
-"16 387 OFFCURVE",
-"16 398 CURVE SMOOTH",
-"16 456 OFFCURVE",
-"57 501 OFFCURVE",
-"57 508 CURVE",
-"44 508 LINE SMOOTH",
-"31 508 OFFCURVE",
-"7 461 OFFCURVE",
-"-15 412 CURVE SMOOTH",
-"-20 399 OFFCURVE",
-"-24 386 OFFCURVE",
-"-24 373 CURVE SMOOTH",
-"-24 355 OFFCURVE",
-"-11 344 OFFCURVE",
-"2 344 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-19 -99 OFFCURVE",
-"-19 -116 OFFCURVE",
-"-19 -125 CURVE SMOOTH",
-"-19 -135 OFFCURVE",
-"-13 -142 OFFCURVE",
-"-13 -153 CURVE SMOOTH",
-"-13 -211 OFFCURVE",
-"-54 -256 OFFCURVE",
-"-54 -263 CURVE",
-"-41 -263 LINE SMOOTH",
-"-28 -263 OFFCURVE",
-"-4 -216 OFFCURVE",
-"18 -167 CURVE SMOOTH",
-"23 -154 OFFCURVE",
-"27 -141 OFFCURVE",
-"27 -128 CURVE SMOOTH",
-"27 -110 OFFCURVE",
-"14 -99 OFFCURVE",
-"1 -99 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0326;
-},
-{
-color = 3;
-glyphname = cedillacomb;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-anchors = (
-{
-name = _cedilla;
-position = "{0, 0}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"60 -195 OFFCURVE",
-"142 -175 OFFCURVE",
-"142 -125 CURVE SMOOTH",
-"142 -87 OFFCURVE",
-"93 -64 OFFCURVE",
-"93 -39 CURVE SMOOTH",
-"93 -33 OFFCURVE",
-"96 -28 OFFCURVE",
-"100 -22 CURVE SMOOTH",
-"110 -13 OFFCURVE",
-"122 -5 OFFCURVE",
-"132 0 CURVE",
-"131 3 OFFCURVE",
-"121 5 OFFCURVE",
-"115 5 CURVE SMOOTH",
-"114 5 OFFCURVE",
-"113 5 OFFCURVE",
-"112 5 CURVE SMOOTH",
-"97 0 OFFCURVE",
-"83 -8 OFFCURVE",
-"73 -19 CURVE SMOOTH",
-"62 -31 OFFCURVE",
-"58 -42 OFFCURVE",
-"58 -51 CURVE SMOOTH",
-"58 -81 OFFCURVE",
-"104 -96 OFFCURVE",
-"104 -128 CURVE SMOOTH",
-"104 -171 OFFCURVE",
-"58 -174 OFFCURVE",
-"30 -178 CURVE SMOOTH",
-"11 -181 OFFCURVE",
-"0 -183 OFFCURVE",
-"0 -187 CURVE SMOOTH",
-"0 -191 OFFCURVE",
-"4 -195 OFFCURVE",
-"25 -195 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-60 -195 OFFCURVE",
-"22 -175 OFFCURVE",
-"22 -125 CURVE SMOOTH",
-"22 -87 OFFCURVE",
-"-27 -64 OFFCURVE",
-"-27 -39 CURVE SMOOTH",
-"-27 -33 OFFCURVE",
-"-24 -28 OFFCURVE",
-"-20 -22 CURVE",
-"-10 -13 OFFCURVE",
-"2 -5 OFFCURVE",
-"12 0 CURVE",
-"11 3 OFFCURVE",
-"1 5 OFFCURVE",
-"-5 5 CURVE SMOOTH",
-"-8 5 LINE",
-"-23 0 OFFCURVE",
-"-37 -8 OFFCURVE",
-"-47 -19 CURVE SMOOTH",
-"-58 -31 OFFCURVE",
-"-62 -42 OFFCURVE",
-"-62 -51 CURVE SMOOTH",
-"-62 -81 OFFCURVE",
-"-16 -96 OFFCURVE",
-"-16 -128 CURVE SMOOTH",
-"-16 -171 OFFCURVE",
-"-62 -174 OFFCURVE",
-"-90 -178 CURVE SMOOTH",
-"-109 -181 OFFCURVE",
-"-120 -183 OFFCURVE",
-"-120 -187 CURVE SMOOTH",
-"-120 -191 OFFCURVE",
-"-116 -195 OFFCURVE",
-"-95 -195 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0327;
-},
-{
-color = 3;
-glyphname = ogonekcomb;
-lastChange = "2022-02-11 08:53:01 +0000";
-layers = (
-{
-anchors = (
-{
-name = _ogonek;
-position = "{0, 0}";
-}
-);
-background = {
-paths = (
-{
-closed = 1;
-nodes = (
-"84 -160 OFFCURVE",
-"131 -145 OFFCURVE",
-"131 -129 CURVE SMOOTH",
-"131 -126 OFFCURVE",
-"129 -126 OFFCURVE",
-"127 -126 CURVE SMOOTH",
-"119 -126 OFFCURVE",
-"93 -137 OFFCURVE",
-"69 -137 CURVE SMOOTH",
-"53 -137 OFFCURVE",
-"41 -128 OFFCURVE",
-"42 -115 CURVE SMOOTH",
-"41 -100 OFFCURVE",
-"55 -80 OFFCURVE",
-"71 -62 CURVE SMOOTH",
-"88 -46 OFFCURVE",
-"107 -29 OFFCURVE",
-"121 0 CURVE",
-"120 1 OFFCURVE",
-"114 2 OFFCURVE",
-"109 2 CURVE SMOOTH",
-"100 2 OFFCURVE",
-"101 -3 OFFCURVE",
-"49 -48 CURVE SMOOTH",
-"26 -67 OFFCURVE",
-"0 -89 OFFCURVE",
-"0 -117 CURVE SMOOTH",
-"2 -150 OFFCURVE",
-"31 -160 OFFCURVE",
-"60 -160 CURVE SMOOTH"
-);
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-22 -157 OFFCURVE",
-"25 -142 OFFCURVE",
-"25 -126 CURVE SMOOTH",
-"25 -123 OFFCURVE",
-"23 -123 OFFCURVE",
-"21 -123 CURVE SMOOTH",
-"13 -123 OFFCURVE",
-"-13 -134 OFFCURVE",
-"-37 -134 CURVE SMOOTH",
-"-53 -134 OFFCURVE",
-"-65 -125 OFFCURVE",
-"-64 -112 CURVE",
-"-65 -97 OFFCURVE",
-"-51 -77 OFFCURVE",
-"-35 -59 CURVE SMOOTH",
-"-18 -43 OFFCURVE",
-"1 -26 OFFCURVE",
-"15 3 CURVE",
-"14 4 OFFCURVE",
-"8 5 OFFCURVE",
-"3 5 CURVE SMOOTH",
-"-6 5 OFFCURVE",
-"-5 0 OFFCURVE",
-"-57 -45 CURVE SMOOTH",
-"-80 -64 OFFCURVE",
-"-106 -86 OFFCURVE",
-"-106 -114 CURVE SMOOTH",
-"-104 -147 OFFCURVE",
-"-75 -157 OFFCURVE",
-"-46 -157 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0328;
-},
-{
-color = 3;
-glyphname = brevebelowcomb;
-lastChange = "2022-02-14 21:32:36 +0000";
-layers = (
-{
-anchors = (
-{
-name = _bottom;
-position = "{0, 0}";
-},
-{
-name = bottom;
-position = "{0, -140}";
-}
-);
-background = {
-components = (
-{
-name = brevecomb;
-transform = "{1, 0, 0, 1, 0, -1000}";
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"31 -203 OFFCURVE",
-"108 -183 OFFCURVE",
-"142 -119 CURVE SMOOTH",
-"144 -116 OFFCURVE",
-"145 -112 OFFCURVE",
-"145 -109 CURVE SMOOTH",
-"145 -104 OFFCURVE",
-"142 -101 OFFCURVE",
-"138 -101 CURVE SMOOTH",
-"135 -101 OFFCURVE",
-"132 -103 OFFCURVE",
-"128 -106 CURVE",
-"103 -135 OFFCURVE",
-"53 -169 OFFCURVE",
-"1 -169 CURVE SMOOTH",
-"-29 -169 OFFCURVE",
-"-54 -153 OFFCURVE",
-"-52 -109 CURVE SMOOTH",
-"-52 -103 OFFCURVE",
-"-56 -100 OFFCURVE",
-"-59 -100 CURVE SMOOTH",
-"-64 -100 OFFCURVE",
-"-71 -105 OFFCURVE",
-"-74 -113 CURVE SMOOTH",
-"-76 -122 OFFCURVE",
-"-76 -132 OFFCURVE",
-"-76 -140 CURVE SMOOTH",
-"-76 -184 OFFCURVE",
-"-52 -203 OFFCURVE",
-"0 -203 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 032E;
-},
-{
-color = 3;
-glyphname = macronbelowcomb;
-lastChange = "2022-02-11 09:30:20 +0000";
-layers = (
-{
-background = {
-components = (
-{
-name = macroncomb;
-transform = "{1, 0, 0, 1, 0, -1030}";
-}
-);
-};
-components = (
-{
-name = macroncomb;
-transform = "{1, 0, 0, 1, 0, -1005}";
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 216;
-}
-);
-unicode = 0331;
-},
-{
-color = 3;
-glyphname = strokeshortcomb;
-lastChange = "2022-02-11 10:40:20 +0000";
-layers = (
-{
-anchors = (
-{
-name = _center;
-position = "{0, -125}";
-}
-);
-background = {
-components = (
-{
-name = macroncomb;
-transform = "{1, 0, 0, 1, 0, -730}";
-}
-);
-};
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-paths = (
-{
-closed = 1;
-nodes = (
-"-57 -143 OFFCURVE",
-"-30 -140 OFFCURVE",
-"-3 -138 CURVE SMOOTH",
-"30 -136 OFFCURVE",
-"63 -134 OFFCURVE",
-"97 -134 CURVE SMOOTH",
-"105 -134 OFFCURVE",
-"108 -125 OFFCURVE",
-"108 -122 CURVE SMOOTH",
-"108 -111 OFFCURVE",
-"22 -107 OFFCURVE",
-"-6 -107 CURVE SMOOTH",
-"-27 -107 OFFCURVE",
-"-89 -106 OFFCURVE",
-"-106 -115 CURVE SMOOTH",
-"-108 -116 LINE",
-"-107 -124 OFFCURVE",
-"-93 -143 OFFCURVE",
-"-87 -143 CURVE SMOOTH"
-);
-}
-);
-width = 0;
-}
-);
-unicode = 0335;
-},
-{
-color = 3;
-glyphname = dieresis;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = dieresiscomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 00A8;
-},
-{
-color = 3;
-glyphname = dotaccent;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = dotaccentcomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02D9;
-},
-{
-color = 3;
-glyphname = grave;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = gravecomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 0060;
-},
-{
-color = 3;
-glyphname = acute;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = acutecomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 00B4;
-},
-{
-color = 3;
-glyphname = hungarumlaut;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = hungarumlautcomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02DD;
-},
-{
-color = 3;
-glyphname = circumflex;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = circumflexcomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02C6;
-},
-{
-color = 3;
-glyphname = caron;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = caroncomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02C7;
-},
-{
-color = 3;
-glyphname = breve;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = brevecomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02D8;
-},
-{
-color = 3;
-glyphname = ring;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = ringcomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02DA;
-},
-{
-color = 3;
-glyphname = tilde;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = tildecomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02DC;
-},
-{
-color = 3;
-glyphname = macron;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = macroncomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 00AF;
-},
-{
-color = 3;
-glyphname = cedilla;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = cedillacomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 00B8;
-},
-{
-color = 3;
-glyphname = ogonek;
-lastChange = "2022-02-14 14:51:39 +0000";
-layers = (
-{
-components = (
-{
-name = ogonekcomb;
-}
-);
-layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
-width = 0;
-}
-);
-unicode = 02DB;
+unicode = 2116;
 },
 {
 color = 8;
@@ -66326,6 +63600,5798 @@ width = 82;
 }
 );
 unicode = 02B9;
+},
+{
+color = 3;
+glyphname = dieresiscomb;
+lastChange = "2022-03-01 11:17:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"315 344 OFFCURVE",
+"325 364 OFFCURVE",
+"329 376 CURVE",
+"331 388 OFFCURVE",
+"341 397 OFFCURVE",
+"352 413 CURVE",
+"352 417 LINE",
+"351 420 OFFCURVE",
+"348 420 OFFCURVE",
+"347 420 CURVE SMOOTH",
+"332 420 OFFCURVE",
+"279 395 OFFCURVE",
+"279 374 CURVE SMOOTH",
+"279 365 OFFCURVE",
+"289 344 OFFCURVE",
+"299 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 344 OFFCURVE",
+"194 364 OFFCURVE",
+"198 376 CURVE SMOOTH",
+"201 388 OFFCURVE",
+"210 397 OFFCURVE",
+"221 413 CURVE",
+"221 417 LINE",
+"220 420 OFFCURVE",
+"217 420 OFFCURVE",
+"216 420 CURVE SMOOTH",
+"202 420 OFFCURVE",
+"148 395 OFFCURVE",
+"148 374 CURVE SMOOTH",
+"148 365 OFFCURVE",
+"158 344 OFFCURVE",
+"168 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 344 OFFCURVE",
+"304 362 OFFCURVE",
+"308 373 CURVE",
+"310 384 OFFCURVE",
+"319 392 OFFCURVE",
+"329 407 CURVE",
+"329 410 LINE",
+"328 413 OFFCURVE",
+"325 413 OFFCURVE",
+"324 413 CURVE SMOOTH",
+"301 413 OFFCURVE",
+"262 390 OFFCURVE",
+"262 371 CURVE SMOOTH",
+"262 363 OFFCURVE",
+"271 344 OFFCURVE",
+"281 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 344 OFFCURVE",
+"213 362 OFFCURVE",
+"217 373 CURVE SMOOTH",
+"220 384 OFFCURVE",
+"228 392 OFFCURVE",
+"238 407 CURVE",
+"238 410 LINE",
+"237 413 OFFCURVE",
+"234 413 OFFCURVE",
+"233 413 CURVE SMOOTH",
+"211 413 OFFCURVE",
+"171 391 OFFCURVE",
+"171 371 CURVE SMOOTH",
+"171 363 OFFCURVE",
+"180 344 OFFCURVE",
+"190 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0308;
+},
+{
+color = 3;
+glyphname = dotaccentcomb;
+lastChange = "2022-03-01 11:17:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"250 343 OFFCURVE",
+"265 348 OFFCURVE",
+"272 360 CURVE SMOOTH",
+"278 371 OFFCURVE",
+"282 382 OFFCURVE",
+"282 388 CURVE SMOOTH",
+"282 400 OFFCURVE",
+"275 407 OFFCURVE",
+"257 407 CURVE SMOOTH",
+"238 407 OFFCURVE",
+"218 386 OFFCURVE",
+"218 361 CURVE SMOOTH",
+"218 358 OFFCURVE",
+"218 355 OFFCURVE",
+"219 352 CURVE SMOOTH",
+"220 346 OFFCURVE",
+"229 343 OFFCURVE",
+"238 343 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 343 OFFCURVE",
+"264 348 OFFCURVE",
+"270 358 CURVE SMOOTH",
+"275 368 OFFCURVE",
+"279 378 OFFCURVE",
+"279 384 CURVE SMOOTH",
+"279 395 OFFCURVE",
+"273 401 OFFCURVE",
+"256 401 CURVE SMOOTH",
+"234 401 OFFCURVE",
+"221 382 OFFCURVE",
+"221 364 CURVE SMOOTH",
+"221 350 OFFCURVE",
+"228 343 OFFCURVE",
+"241 343 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0307;
+},
+{
+color = 3;
+glyphname = gravecomb;
+lastChange = "2022-03-01 13:05:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"270 342 OFFCURVE",
+"280 345 OFFCURVE",
+"280 349 CURVE SMOOTH",
+"280 350 OFFCURVE",
+"279 351 OFFCURVE",
+"276 352 CURVE SMOOTH",
+"240 367 OFFCURVE",
+"173 436 OFFCURVE",
+"158 446 CURVE SMOOTH",
+"153 450 OFFCURVE",
+"139 452 OFFCURVE",
+"128 452 CURVE SMOOTH",
+"118 452 OFFCURVE",
+"110 451 OFFCURVE",
+"110 446 CURVE SMOOTH",
+"111 439 OFFCURVE",
+"113 429 OFFCURVE",
+"144 409 CURVE SMOOTH",
+"149 406 OFFCURVE",
+"254 346 OFFCURVE",
+"263 345 CURVE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"269 342 OFFCURVE",
+"280 345 OFFCURVE",
+"281 349 CURVE",
+"278 351 LINE SMOOTH",
+"250 365 OFFCURVE",
+"200 427 OFFCURVE",
+"194 434 CURVE SMOOTH",
+"185 443 OFFCURVE",
+"176 444 OFFCURVE",
+"162 444 CURVE SMOOTH",
+"154 444 OFFCURVE",
+"147 439 OFFCURVE",
+"147 433 CURVE SMOOTH",
+"146 428 OFFCURVE",
+"147 421 OFFCURVE",
+"171 403 CURVE SMOOTH",
+"175 400 OFFCURVE",
+"255 346 OFFCURVE",
+"263 345 CURVE"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0300;
+},
+{
+color = 3;
+glyphname = acutecomb;
+lastChange = "2022-03-01 13:05:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"233 344 OFFCURVE",
+"235 344 OFFCURVE",
+"237 345 CURVE",
+"245 346 OFFCURVE",
+"351 406 OFFCURVE",
+"356 409 CURVE SMOOTH",
+"387 429 OFFCURVE",
+"389 439 OFFCURVE",
+"390 446 CURVE SMOOTH",
+"390 451 OFFCURVE",
+"382 452 OFFCURVE",
+"372 452 CURVE SMOOTH",
+"361 452 OFFCURVE",
+"347 450 OFFCURVE",
+"342 446 CURVE SMOOTH",
+"326 436 OFFCURVE",
+"260 367 OFFCURVE",
+"224 352 CURVE SMOOTH",
+"215 348 OFFCURVE",
+"223 344 OFFCURVE",
+"230 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"245 346 OFFCURVE",
+"339 400 OFFCURVE",
+"343 403 CURVE SMOOTH",
+"371 421 OFFCURVE",
+"374 428 OFFCURVE",
+"375 433 CURVE SMOOTH",
+"377 439 OFFCURVE",
+"368 444 OFFCURVE",
+"359 444 CURVE SMOOTH",
+"346 444 OFFCURVE",
+"337 443 OFFCURVE",
+"326 434 CURVE SMOOTH",
+"318 427 OFFCURVE",
+"256 367 OFFCURVE",
+"224 353 CURVE",
+"221 351 LINE",
+"220 345 OFFCURVE",
+"231 342 OFFCURVE",
+"237 345 CURVE"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0301;
+},
+{
+color = 3;
+glyphname = hungarumlautcomb;
+lastChange = "2022-03-01 11:26:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"202 344 OFFCURVE",
+"207 346 OFFCURVE",
+"209 351 CURVE SMOOTH",
+"213 360 OFFCURVE",
+"251 454 OFFCURVE",
+"254 463 CURVE SMOOTH",
+"256 470 OFFCURVE",
+"245 473 OFFCURVE",
+"233 473 CURVE SMOOTH",
+"220 473 OFFCURVE",
+"208 470 OFFCURVE",
+"208 462 CURVE SMOOTH",
+"208 433 OFFCURVE",
+"202 394 OFFCURVE",
+"192 361 CURVE SMOOTH",
+"191 359 OFFCURVE",
+"191 356 OFFCURVE",
+"191 354 CURVE SMOOTH",
+"191 347 OFFCURVE",
+"194 344 OFFCURVE",
+"198 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 344 OFFCURVE",
+"310 346 OFFCURVE",
+"312 351 CURVE SMOOTH",
+"317 360 OFFCURVE",
+"355 454 OFFCURVE",
+"358 463 CURVE SMOOTH",
+"360 470 OFFCURVE",
+"348 473 OFFCURVE",
+"336 473 CURVE SMOOTH",
+"324 473 OFFCURVE",
+"311 470 OFFCURVE",
+"311 462 CURVE SMOOTH",
+"311 433 OFFCURVE",
+"305 394 OFFCURVE",
+"295 361 CURVE SMOOTH",
+"294 359 OFFCURVE",
+"294 356 OFFCURVE",
+"294 354 CURVE SMOOTH",
+"294 347 OFFCURVE",
+"297 344 OFFCURVE",
+"301 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"210 344 OFFCURVE",
+"214 346 OFFCURVE",
+"217 350 CURVE SMOOTH",
+"221 359 OFFCURVE",
+"263 444 OFFCURVE",
+"267 452 CURVE SMOOTH",
+"269 459 OFFCURVE",
+"260 463 OFFCURVE",
+"250 463 CURVE SMOOTH",
+"240 463 OFFCURVE",
+"226 459 OFFCURVE",
+"225 451 CURVE SMOOTH",
+"222 425 OFFCURVE",
+"213 389 OFFCURVE",
+"201 359 CURVE SMOOTH",
+"200 358 OFFCURVE",
+"199 355 OFFCURVE",
+"199 353 CURVE SMOOTH",
+"198 347 OFFCURVE",
+"203 344 OFFCURVE",
+"207 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"289 344 OFFCURVE",
+"293 346 OFFCURVE",
+"296 350 CURVE SMOOTH",
+"301 359 OFFCURVE",
+"343 444 OFFCURVE",
+"346 452 CURVE SMOOTH",
+"349 459 OFFCURVE",
+"336 463 OFFCURVE",
+"326 463 CURVE SMOOTH",
+"316 463 OFFCURVE",
+"305 459 OFFCURVE",
+"304 451 CURVE SMOOTH",
+"301 425 OFFCURVE",
+"292 389 OFFCURVE",
+"279 359 CURVE SMOOTH",
+"278 358 OFFCURVE",
+"278 355 OFFCURVE",
+"278 353 CURVE SMOOTH",
+"277 347 OFFCURVE",
+"282 344 OFFCURVE",
+"286 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 030B;
+},
+{
+color = 3;
+glyphname = caroncomb.alt;
+lastChange = "2022-03-01 11:27:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{250, 585}";
+}
+);
+background = {
+anchors = (
+{
+name = _topright;
+position = "{250, 585}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"256 434 OFFCURVE",
+"266 445 OFFCURVE",
+"272 459 CURVE SMOOTH",
+"288 490 OFFCURVE",
+"315 568 OFFCURVE",
+"318 577 CURVE SMOOTH",
+"320 584 OFFCURVE",
+"309 587 OFFCURVE",
+"297 587 CURVE SMOOTH",
+"284 587 OFFCURVE",
+"271 584 OFFCURVE",
+"271 576 CURVE SMOOTH",
+"271 547 OFFCURVE",
+"264 486 OFFCURVE",
+"251 444 CURVE SMOOTH",
+"249 437 OFFCURVE",
+"250 434 OFFCURVE",
+"252 434 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 449 OFFCURVE",
+"274 459 OFFCURVE",
+"279 472 CURVE SMOOTH",
+"292 500 OFFCURVE",
+"315 571 OFFCURVE",
+"317 579 CURVE SMOOTH",
+"319 585 OFFCURVE",
+"305 588 OFFCURVE",
+"295 588 CURVE SMOOTH",
+"284 588 OFFCURVE",
+"273 585 OFFCURVE",
+"273 578 CURVE SMOOTH",
+"273 552 OFFCURVE",
+"267 496 OFFCURVE",
+"257 458 CURVE SMOOTH",
+"255 452 OFFCURVE",
+"256 449 OFFCURVE",
+"257 449 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb;
+lastChange = "2022-03-01 11:30:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"148 344 OFFCURVE",
+"150 345 OFFCURVE",
+"152 346 CURVE",
+"158 347 OFFCURVE",
+"253 414 OFFCURVE",
+"264 424 CURVE",
+"269 416 OFFCURVE",
+"350 347 OFFCURVE",
+"354 346 CURVE",
+"359 342 OFFCURVE",
+"367 345 OFFCURVE",
+"367 350 CURVE SMOOTH",
+"367 351 OFFCURVE",
+"366 353 OFFCURVE",
+"364 354 CURVE SMOOTH",
+"357 359 OFFCURVE",
+"287 457 OFFCURVE",
+"283 459 CURVE",
+"281 461 OFFCURVE",
+"276 462 OFFCURVE",
+"271 462 CURVE SMOOTH",
+"264 462 OFFCURVE",
+"257 461 OFFCURVE",
+"254 459 CURVE SMOOTH",
+"247 455 OFFCURVE",
+"160 363 OFFCURVE",
+"143 354 CURVE",
+"136 349 OFFCURVE",
+"141 344 OFFCURVE",
+"147 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 344 OFFCURVE",
+"162 345 OFFCURVE",
+"164 346 CURVE",
+"184 356 OFFCURVE",
+"255 404 OFFCURVE",
+"265 413 CURVE",
+"279 396 OFFCURVE",
+"310 363 OFFCURVE",
+"321 352 CURVE",
+"326 347 OFFCURVE",
+"329 344 OFFCURVE",
+"334 344 CURVE SMOOTH",
+"338 344 OFFCURVE",
+"341 346 OFFCURVE",
+"341 349 CURVE SMOOTH",
+"341 350 OFFCURVE",
+"340 353 OFFCURVE",
+"339 355 CURVE SMOOTH",
+"337 359 OFFCURVE",
+"288 446 OFFCURVE",
+"285 449 CURVE",
+"283 451 OFFCURVE",
+"280 452 OFFCURVE",
+"275 452 CURVE SMOOTH",
+"266 452 OFFCURVE",
+"263 450 OFFCURVE",
+"261 449 CURVE SMOOTH",
+"254 445 OFFCURVE",
+"169 366 OFFCURVE",
+"153 355 CURVE",
+"148 351 OFFCURVE",
+"152 344 OFFCURVE",
+"158 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0302;
+},
+{
+color = 3;
+glyphname = caroncomb;
+lastChange = "2022-03-01 11:30:46 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"256 344 OFFCURVE",
+"263 345 OFFCURVE",
+"266 347 CURVE",
+"274 350 OFFCURVE",
+"360 442 OFFCURVE",
+"377 452 CURVE SMOOTH",
+"384 457 OFFCURVE",
+"380 462 OFFCURVE",
+"375 462 CURVE SMOOTH",
+"374 462 OFFCURVE",
+"372 461 OFFCURVE",
+"370 460 CURVE",
+"363 459 OFFCURVE",
+"268 392 OFFCURVE",
+"256 382 CURVE",
+"252 390 OFFCURVE",
+"172 459 OFFCURVE",
+"167 460 CURVE",
+"162 464 OFFCURVE",
+"153 461 OFFCURVE",
+"153 456 CURVE SMOOTH",
+"153 455 OFFCURVE",
+"154 453 OFFCURVE",
+"156 452 CURVE SMOOTH",
+"164 447 OFFCURVE",
+"233 349 OFFCURVE",
+"237 347 CURVE",
+"239 345 OFFCURVE",
+"245 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"364 452 OFFCURVE",
+"362 451 OFFCURVE",
+"360 450 CURVE",
+"340 440 OFFCURVE",
+"269 392 OFFCURVE",
+"259 383 CURVE",
+"245 400 OFFCURVE",
+"214 433 OFFCURVE",
+"203 444 CURVE",
+"198 449 OFFCURVE",
+"195 452 OFFCURVE",
+"190 452 CURVE SMOOTH",
+"186 452 OFFCURVE",
+"183 450 OFFCURVE",
+"183 447 CURVE SMOOTH",
+"183 446 OFFCURVE",
+"184 443 OFFCURVE",
+"185 441 CURVE SMOOTH",
+"187 437 OFFCURVE",
+"236 350 OFFCURVE",
+"239 347 CURVE",
+"241 345 OFFCURVE",
+"244 344 OFFCURVE",
+"249 344 CURVE SMOOTH",
+"258 344 OFFCURVE",
+"261 346 OFFCURVE",
+"263 347 CURVE SMOOTH",
+"270 351 OFFCURVE",
+"355 430 OFFCURVE",
+"371 441 CURVE",
+"376 445 OFFCURVE",
+"372 452 OFFCURVE",
+"366 452 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 030C;
+},
+{
+color = 3;
+glyphname = brevecomb;
+lastChange = "2022-03-01 11:49:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"281 344 OFFCURVE",
+"358 364 OFFCURVE",
+"392 428 CURVE SMOOTH",
+"394 431 OFFCURVE",
+"395 435 OFFCURVE",
+"395 438 CURVE SMOOTH",
+"395 443 OFFCURVE",
+"392 446 OFFCURVE",
+"388 446 CURVE SMOOTH",
+"385 446 OFFCURVE",
+"382 444 OFFCURVE",
+"378 441 CURVE",
+"353 412 OFFCURVE",
+"303 378 OFFCURVE",
+"251 378 CURVE SMOOTH",
+"221 378 OFFCURVE",
+"196 394 OFFCURVE",
+"198 438 CURVE SMOOTH",
+"198 444 OFFCURVE",
+"194 447 OFFCURVE",
+"191 447 CURVE SMOOTH",
+"186 447 OFFCURVE",
+"179 442 OFFCURVE",
+"176 434 CURVE SMOOTH",
+"174 425 OFFCURVE",
+"174 415 OFFCURVE",
+"174 407 CURVE SMOOTH",
+"174 363 OFFCURVE",
+"198 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"282 344 OFFCURVE",
+"346 362 OFFCURVE",
+"374 420 CURVE SMOOTH",
+"376 423 OFFCURVE",
+"377 427 OFFCURVE",
+"377 429 CURVE SMOOTH",
+"377 434 OFFCURVE",
+"374 437 OFFCURVE",
+"371 437 CURVE SMOOTH",
+"368 437 OFFCURVE",
+"365 435 OFFCURVE",
+"362 432 CURVE",
+"342 406 OFFCURVE",
+"302 377 OFFCURVE",
+"257 377 CURVE SMOOTH",
+"232 377 OFFCURVE",
+"211 389 OFFCURVE",
+"212 429 CURVE SMOOTH",
+"212 435 OFFCURVE",
+"209 438 OFFCURVE",
+"205 438 CURVE SMOOTH",
+"200 438 OFFCURVE",
+"197 435 OFFCURVE",
+"194 427 CURVE SMOOTH",
+"191 418 OFFCURVE",
+"190 409 OFFCURVE",
+"190 400 CURVE SMOOTH",
+"190 367 OFFCURVE",
+"210 344 OFFCURVE",
+"252 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0306;
+},
+{
+color = 3;
+glyphname = ringcomb;
+lastChange = "2022-03-01 11:51:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"300 344 OFFCURVE",
+"348 390 OFFCURVE",
+"350 436 CURVE SMOOTH",
+"350 460 OFFCURVE",
+"334 486 OFFCURVE",
+"307 486 CURVE SMOOTH",
+"284 486 OFFCURVE",
+"262 473 OFFCURVE",
+"247 455 CURVE",
+"230 455 OFFCURVE",
+"209 401 OFFCURVE",
+"209 379 CURVE SMOOTH",
+"209 357 OFFCURVE",
+"227 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 362 OFFCURVE",
+"247 372 OFFCURVE",
+"247 382 CURVE SMOOTH",
+"248 415 OFFCURVE",
+"264 434 OFFCURVE",
+"274 445 CURVE SMOOTH",
+"277 448 OFFCURVE",
+"278 451 OFFCURVE",
+"278 452 CURVE SMOOTH",
+"278 456 OFFCURVE",
+"272 455 OFFCURVE",
+"271 456 CURVE",
+"281 462 OFFCURVE",
+"291 469 OFFCURVE",
+"303 469 CURVE SMOOTH",
+"321 469 OFFCURVE",
+"324 447 OFFCURVE",
+"324 434 CURVE SMOOTH",
+"323 404 OFFCURVE",
+"298 362 OFFCURVE",
+"263 362 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 344 OFFCURVE",
+"340 386 OFFCURVE",
+"341 428 CURVE SMOOTH",
+"341 449 OFFCURVE",
+"328 473 OFFCURVE",
+"302 473 CURVE SMOOTH",
+"283 473 OFFCURVE",
+"262 461 OFFCURVE",
+"249 445 CURVE",
+"235 445 OFFCURVE",
+"218 396 OFFCURVE",
+"218 376 CURVE SMOOTH",
+"218 356 OFFCURVE",
+"236 344 OFFCURVE",
+"255 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 362 OFFCURVE",
+"252 369 OFFCURVE",
+"252 379 CURVE SMOOTH",
+"253 409 OFFCURVE",
+"267 426 OFFCURVE",
+"275 436 CURVE SMOOTH",
+"277 439 OFFCURVE",
+"278 441 OFFCURVE",
+"278 442 CURVE SMOOTH",
+"278 446 OFFCURVE",
+"273 445 OFFCURVE",
+"272 446 CURVE",
+"281 451 OFFCURVE",
+"289 456 OFFCURVE",
+"299 456 CURVE SMOOTH",
+"314 456 OFFCURVE",
+"317 438 OFFCURVE",
+"317 426 CURVE SMOOTH",
+"316 399 OFFCURVE",
+"295 362 OFFCURVE",
+"266 362 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 030A;
+},
+{
+color = 3;
+glyphname = ringcomb_acutecomb;
+lastChange = "2022-03-01 12:01:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = ringcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 110, 90}";
+}
+);
+};
+components = (
+{
+name = ringcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 98, 80}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = tildecomb;
+lastChange = "2022-03-01 12:05:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"323 344 OFFCURVE",
+"349 366 OFFCURVE",
+"357 399 CURVE",
+"357 403 OFFCURVE",
+"356 403 OFFCURVE",
+"348 403 CURVE",
+"345 392 OFFCURVE",
+"325 376 OFFCURVE",
+"302 376 CURVE SMOOTH",
+"276 376 OFFCURVE",
+"238 404 OFFCURVE",
+"207 404 CURVE SMOOTH",
+"177 404 OFFCURVE",
+"151 382 OFFCURVE",
+"144 350 CURVE SMOOTH",
+"143 345 OFFCURVE",
+"146 345 OFFCURVE",
+"151 345 CURVE",
+"155 357 OFFCURVE",
+"174 372 OFFCURVE",
+"198 372 CURVE SMOOTH",
+"224 372 OFFCURVE",
+"262 344 OFFCURVE",
+"292 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"311 344 OFFCURVE",
+"342 365 OFFCURVE",
+"342 391 CURVE",
+"342 395 OFFCURVE",
+"340 398 OFFCURVE",
+"336 398 CURVE SMOOTH",
+"329 398 OFFCURVE",
+"324 373 OFFCURVE",
+"293 373 CURVE SMOOTH",
+"272 373 OFFCURVE",
+"240 399 OFFCURVE",
+"214 399 CURVE SMOOTH",
+"189 399 OFFCURVE",
+"165 382 OFFCURVE",
+"159 352 CURVE SMOOTH",
+"158 348 OFFCURVE",
+"160 345 OFFCURVE",
+"162 345 CURVE SMOOTH",
+"169 345 OFFCURVE",
+"173 369 OFFCURVE",
+"207 369 CURVE SMOOTH",
+"228 369 OFFCURVE",
+"260 344 OFFCURVE",
+"285 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0303;
+},
+{
+color = 3;
+glyphname = tildecomb_dotaccentcomb;
+lastChange = "2022-03-01 12:06:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = dotaccentcomb;
+transform = "{1, 0, 0, 1, 0, 90}";
+}
+);
+};
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = dotaccentcomb;
+transform = "{1, 0, 0, 1, 10, 80}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = tildecomb_macroncomb;
+lastChange = "2022-03-01 12:07:42 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = macroncomb;
+transform = "{1, 0, 0, 1, 0, 80}";
+}
+);
+};
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = macroncomb;
+transform = "{1, 0, 0, 1, 10, 60}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = macroncomb;
+lastChange = "2022-03-01 13:01:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 359 OFFCURVE",
+"220 362 OFFCURVE",
+"247 364 CURVE SMOOTH",
+"280 366 OFFCURVE",
+"313 368 OFFCURVE",
+"347 368 CURVE SMOOTH",
+"355 368 OFFCURVE",
+"358 377 OFFCURVE",
+"358 380 CURVE SMOOTH",
+"358 391 OFFCURVE",
+"272 395 OFFCURVE",
+"244 395 CURVE SMOOTH",
+"223 395 OFFCURVE",
+"161 396 OFFCURVE",
+"144 387 CURVE SMOOTH",
+"142 386 LINE",
+"143 378 OFFCURVE",
+"157 359 OFFCURVE",
+"163 359 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 361 OFFCURVE",
+"226 363 OFFCURVE",
+"248 365 CURVE SMOOTH",
+"274 367 OFFCURVE",
+"300 369 OFFCURVE",
+"328 369 CURVE SMOOTH",
+"334 369 OFFCURVE",
+"336 378 OFFCURVE",
+"336 381 CURVE SMOOTH",
+"336 388 OFFCURVE",
+"294 395 OFFCURVE",
+"245 395 CURVE SMOOTH",
+"186 395 OFFCURVE",
+"164 395 OFFCURVE",
+"164 386 CURVE SMOOTH",
+"164 378 OFFCURVE",
+"171 361 OFFCURVE",
+"180 361 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0304;
+},
+{
+color = 3;
+glyphname = hookabovecomb;
+lastChange = "2022-03-01 12:18:08 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"248 343 OFFCURVE",
+"261 345 OFFCURVE",
+"261 349 CURVE",
+"265 361 OFFCURVE",
+"280 377 OFFCURVE",
+"301 393 CURVE SMOOTH",
+"327 411 OFFCURVE",
+"357 432 OFFCURVE",
+"357 459 CURVE SMOOTH",
+"357 488 OFFCURVE",
+"329 496 OFFCURVE",
+"302 496 CURVE SMOOTH",
+"278 496 OFFCURVE",
+"229 482 OFFCURVE",
+"228 467 CURVE",
+"227 463 OFFCURVE",
+"229 460 OFFCURVE",
+"235 460 CURVE SMOOTH",
+"243 460 OFFCURVE",
+"266 474 OFFCURVE",
+"290 474 CURVE SMOOTH",
+"305 474 OFFCURVE",
+"315 467 OFFCURVE",
+"315 457 CURVE SMOOTH",
+"315 443 OFFCURVE",
+"299 423 OFFCURVE",
+"280 406 CURVE SMOOTH",
+"262 391 OFFCURVE",
+"241 375 OFFCURVE",
+"238 349 CURVE SMOOTH",
+"238 345 OFFCURVE",
+"240 343 OFFCURVE",
+"245 343 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 344 OFFCURVE",
+"259 347 OFFCURVE",
+"261 352 CURVE SMOOTH",
+"266 363 OFFCURVE",
+"275 374 OFFCURVE",
+"293 388 CURVE SMOOTH",
+"316 405 OFFCURVE",
+"341 424 OFFCURVE",
+"341 448 CURVE SMOOTH",
+"341 475 OFFCURVE",
+"318 484 OFFCURVE",
+"293 484 CURVE SMOOTH",
+"266 484 OFFCURVE",
+"231 471 OFFCURVE",
+"231 456 CURVE",
+"231 452 OFFCURVE",
+"233 449 OFFCURVE",
+"238 449 CURVE SMOOTH",
+"244 449 OFFCURVE",
+"261 462 OFFCURVE",
+"285 462 CURVE SMOOTH",
+"298 462 OFFCURVE",
+"304 456 OFFCURVE",
+"304 447 CURVE SMOOTH",
+"304 434 OFFCURVE",
+"291 416 OFFCURVE",
+"275 400 CURVE SMOOTH",
+"260 387 OFFCURVE",
+"241 370 OFFCURVE",
+"241 352 CURVE SMOOTH",
+"241 346 OFFCURVE",
+"244 344 OFFCURVE",
+"249 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0309;
+},
+{
+color = 3;
+glyphname = dblgravecomb;
+lastChange = "2022-03-01 12:19:57 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 344 OFFCURVE",
+"195 344 OFFCURVE",
+"197 344 CURVE SMOOTH",
+"203 344 OFFCURVE",
+"208 346 OFFCURVE",
+"208 349 CURVE SMOOTH",
+"208 350 OFFCURVE",
+"207 351 OFFCURVE",
+"204 352 CURVE SMOOTH",
+"168 367 OFFCURVE",
+"101 436 OFFCURVE",
+"86 446 CURVE SMOOTH",
+"81 450 OFFCURVE",
+"67 452 OFFCURVE",
+"56 452 CURVE SMOOTH",
+"46 452 OFFCURVE",
+"38 451 OFFCURVE",
+"38 446 CURVE SMOOTH",
+"39 439 OFFCURVE",
+"41 429 OFFCURVE",
+"72 409 CURVE SMOOTH",
+"77 406 OFFCURVE",
+"182 346 OFFCURVE",
+"191 345 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 334 OFFCURVE",
+"311 336 OFFCURVE",
+"311 339 CURVE SMOOTH",
+"311 340 OFFCURVE",
+"310 341 OFFCURVE",
+"308 343 CURVE",
+"276 361 OFFCURVE",
+"224 435 OFFCURVE",
+"210 445 CURVE",
+"205 450 OFFCURVE",
+"187 455 OFFCURVE",
+"176 455 CURVE SMOOTH",
+"170 455 OFFCURVE",
+"166 454 OFFCURVE",
+"165 451 CURVE",
+"165 444 OFFCURVE",
+"165 434 OFFCURVE",
+"191 412 CURVE",
+"196 409 OFFCURVE",
+"287 339 OFFCURVE",
+"296 337 CURVE",
+"298 335 OFFCURVE",
+"300 334 OFFCURVE",
+"303 334 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 343 OFFCURVE",
+"201 343 OFFCURVE",
+"202 343 CURVE SMOOTH",
+"207 343 OFFCURVE",
+"211 345 OFFCURVE",
+"212 348 CURVE SMOOTH",
+"212 349 OFFCURVE",
+"212 352 OFFCURVE",
+"209 353 CURVE SMOOTH",
+"181 367 OFFCURVE",
+"132 427 OFFCURVE",
+"126 432 CURVE SMOOTH",
+"118 439 OFFCURVE",
+"110 441 OFFCURVE",
+"100 441 CURVE SMOOTH",
+"85 441 OFFCURVE",
+"81 435 OFFCURVE",
+"81 430 CURVE SMOOTH",
+"81 424 OFFCURVE",
+"84 417 OFFCURVE",
+"105 402 CURVE SMOOTH",
+"109 399 OFFCURVE",
+"188 345 OFFCURVE",
+"195 344 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"290 343 OFFCURVE",
+"294 343 OFFCURVE",
+"295 343 CURVE SMOOTH",
+"300 343 OFFCURVE",
+"304 345 OFFCURVE",
+"305 348 CURVE SMOOTH",
+"305 349 OFFCURVE",
+"305 352 OFFCURVE",
+"302 353 CURVE SMOOTH",
+"274 367 OFFCURVE",
+"225 427 OFFCURVE",
+"219 432 CURVE SMOOTH",
+"211 439 OFFCURVE",
+"203 441 OFFCURVE",
+"193 441 CURVE SMOOTH",
+"178 441 OFFCURVE",
+"174 435 OFFCURVE",
+"174 430 CURVE SMOOTH",
+"174 424 OFFCURVE",
+"177 417 OFFCURVE",
+"198 402 CURVE SMOOTH",
+"202 399 OFFCURVE",
+"281 345 OFFCURVE",
+"288 344 CURVE"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 030F;
+},
+{
+color = 3;
+glyphname = breveinvertedcomb;
+lastChange = "2022-03-01 11:49:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"356 344 OFFCURVE",
+"363 349 OFFCURVE",
+"366 356 CURVE",
+"368 366 OFFCURVE",
+"368 376 OFFCURVE",
+"368 384 CURVE SMOOTH",
+"368 428 OFFCURVE",
+"321 447 OFFCURVE",
+"291 447 CURVE SMOOTH",
+"260 447 OFFCURVE",
+"183 427 OFFCURVE",
+"150 363 CURVE SMOOTH",
+"148 359 OFFCURVE",
+"147 355 OFFCURVE",
+"147 352 CURVE SMOOTH",
+"147 348 OFFCURVE",
+"150 345 OFFCURVE",
+"154 345 CURVE SMOOTH",
+"157 345 OFFCURVE",
+"160 347 OFFCURVE",
+"164 350 CURVE",
+"189 379 OFFCURVE",
+"239 413 OFFCURVE",
+"290 413 CURVE SMOOTH",
+"321 413 OFFCURVE",
+"345 396 OFFCURVE",
+"343 352 CURVE SMOOTH",
+"343 347 OFFCURVE",
+"347 344 OFFCURVE",
+"351 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"259 438 OFFCURVE",
+"195 420 OFFCURVE",
+"167 362 CURVE SMOOTH",
+"165 359 OFFCURVE",
+"164 355 OFFCURVE",
+"164 353 CURVE SMOOTH",
+"164 348 OFFCURVE",
+"167 345 OFFCURVE",
+"170 345 CURVE SMOOTH",
+"173 345 OFFCURVE",
+"176 347 OFFCURVE",
+"179 350 CURVE",
+"199 376 OFFCURVE",
+"239 405 OFFCURVE",
+"284 405 CURVE SMOOTH",
+"309 405 OFFCURVE",
+"330 393 OFFCURVE",
+"329 353 CURVE SMOOTH",
+"329 347 OFFCURVE",
+"332 344 OFFCURVE",
+"336 344 CURVE SMOOTH",
+"341 344 OFFCURVE",
+"344 347 OFFCURVE",
+"347 355 CURVE SMOOTH",
+"350 364 OFFCURVE",
+"351 373 OFFCURVE",
+"351 382 CURVE SMOOTH",
+"351 415 OFFCURVE",
+"331 438 OFFCURVE",
+"289 438 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0311;
+},
+{
+color = 3;
+glyphname = commaturnedabovecomb;
+lastChange = "2022-03-01 12:21:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"272 344 OFFCURVE",
+"272 361 OFFCURVE",
+"272 370 CURVE SMOOTH",
+"272 380 OFFCURVE",
+"266 387 OFFCURVE",
+"266 398 CURVE SMOOTH",
+"266 456 OFFCURVE",
+"307 501 OFFCURVE",
+"307 508 CURVE",
+"294 508 LINE SMOOTH",
+"281 508 OFFCURVE",
+"257 461 OFFCURVE",
+"235 412 CURVE SMOOTH",
+"230 399 OFFCURVE",
+"226 386 OFFCURVE",
+"226 373 CURVE SMOOTH",
+"226 355 OFFCURVE",
+"239 344 OFFCURVE",
+"252 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 344 OFFCURVE",
+"270 359 OFFCURVE",
+"270 368 CURVE SMOOTH",
+"270 381 OFFCURVE",
+"265 383 OFFCURVE",
+"268 403 CURVE SMOOTH",
+"273 446 OFFCURVE",
+"311 487 OFFCURVE",
+"312 493 CURVE",
+"301 493 LINE SMOOTH",
+"288 493 OFFCURVE",
+"260 453 OFFCURVE",
+"239 409 CURVE SMOOTH",
+"233 397 OFFCURVE",
+"229 382 OFFCURVE",
+"228 370 CURVE SMOOTH",
+"226 354 OFFCURVE",
+"236 344 OFFCURVE",
+"249 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0312;
+},
+{
+color = 3;
+glyphname = horncomb;
+lastChange = "2022-03-01 11:00:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _horn;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _horn;
+position = "{250, 244}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"318 228 OFFCURVE",
+"350 275 OFFCURVE",
+"356 326 CURVE SMOOTH",
+"357 332 OFFCURVE",
+"349 336 OFFCURVE",
+"340 336 CURVE SMOOTH",
+"330 336 OFFCURVE",
+"320 332 OFFCURVE",
+"319 325 CURVE SMOOTH",
+"312 274 OFFCURVE",
+"297 244 OFFCURVE",
+"250 244 CURVE",
+"249 235 OFFCURVE",
+"256 228 OFFCURVE",
+"268 228 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"318 228 OFFCURVE",
+"350 275 OFFCURVE",
+"356 326 CURVE SMOOTH",
+"357 332 OFFCURVE",
+"349 336 OFFCURVE",
+"340 336 CURVE SMOOTH",
+"330 336 OFFCURVE",
+"320 332 OFFCURVE",
+"319 325 CURVE SMOOTH",
+"312 274 OFFCURVE",
+"297 244 OFFCURVE",
+"250 244 CURVE",
+"249 235 OFFCURVE",
+"256 228 OFFCURVE",
+"268 228 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 031B;
+},
+{
+color = 3;
+glyphname = dotbelowcomb;
+lastChange = "2022-03-01 13:03:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -164 OFFCURVE",
+"265 -159 OFFCURVE",
+"272 -147 CURVE SMOOTH",
+"278 -136 OFFCURVE",
+"282 -125 OFFCURVE",
+"282 -119 CURVE SMOOTH",
+"282 -107 OFFCURVE",
+"275 -100 OFFCURVE",
+"257 -100 CURVE SMOOTH",
+"238 -100 OFFCURVE",
+"218 -121 OFFCURVE",
+"218 -146 CURVE SMOOTH",
+"218 -149 OFFCURVE",
+"218 -152 OFFCURVE",
+"219 -155 CURVE SMOOTH",
+"220 -161 OFFCURVE",
+"229 -164 OFFCURVE",
+"238 -164 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -158 OFFCURVE",
+"264 -153 OFFCURVE",
+"270 -143 CURVE SMOOTH",
+"275 -133 OFFCURVE",
+"279 -123 OFFCURVE",
+"279 -117 CURVE SMOOTH",
+"279 -106 OFFCURVE",
+"273 -100 OFFCURVE",
+"256 -100 CURVE SMOOTH",
+"234 -100 OFFCURVE",
+"221 -119 OFFCURVE",
+"221 -137 CURVE SMOOTH",
+"221 -151 OFFCURVE",
+"228 -158 OFFCURVE",
+"241 -158 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0323;
+},
+{
+color = 3;
+glyphname = dieresisbelowcomb;
+lastChange = "2022-03-01 13:03:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"315 -176 OFFCURVE",
+"325 -156 OFFCURVE",
+"329 -144 CURVE",
+"331 -132 OFFCURVE",
+"341 -123 OFFCURVE",
+"352 -107 CURVE",
+"352 -103 LINE",
+"351 -100 OFFCURVE",
+"348 -100 OFFCURVE",
+"347 -100 CURVE SMOOTH",
+"332 -100 OFFCURVE",
+"279 -125 OFFCURVE",
+"279 -146 CURVE SMOOTH",
+"279 -155 OFFCURVE",
+"289 -176 OFFCURVE",
+"299 -176 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 -176 OFFCURVE",
+"194 -156 OFFCURVE",
+"198 -144 CURVE SMOOTH",
+"201 -132 OFFCURVE",
+"210 -123 OFFCURVE",
+"221 -107 CURVE",
+"221 -103 LINE",
+"220 -100 OFFCURVE",
+"217 -100 OFFCURVE",
+"216 -100 CURVE SMOOTH",
+"202 -100 OFFCURVE",
+"148 -125 OFFCURVE",
+"148 -146 CURVE SMOOTH",
+"148 -155 OFFCURVE",
+"158 -176 OFFCURVE",
+"168 -176 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 -169 OFFCURVE",
+"304 -151 OFFCURVE",
+"308 -140 CURVE",
+"310 -129 OFFCURVE",
+"319 -121 OFFCURVE",
+"329 -106 CURVE",
+"329 -103 LINE",
+"328 -100 OFFCURVE",
+"325 -100 OFFCURVE",
+"324 -100 CURVE SMOOTH",
+"301 -100 OFFCURVE",
+"262 -123 OFFCURVE",
+"262 -142 CURVE SMOOTH",
+"262 -150 OFFCURVE",
+"271 -169 OFFCURVE",
+"281 -169 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 -169 OFFCURVE",
+"213 -151 OFFCURVE",
+"217 -140 CURVE SMOOTH",
+"220 -129 OFFCURVE",
+"228 -121 OFFCURVE",
+"238 -106 CURVE",
+"238 -103 LINE",
+"237 -100 OFFCURVE",
+"234 -100 OFFCURVE",
+"233 -100 CURVE SMOOTH",
+"211 -100 OFFCURVE",
+"171 -122 OFFCURVE",
+"171 -142 CURVE SMOOTH",
+"171 -150 OFFCURVE",
+"180 -169 OFFCURVE",
+"190 -169 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0324;
+},
+{
+color = 3;
+glyphname = commaaccentcomb;
+lastChange = "2022-03-01 13:05:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"231 -99 OFFCURVE",
+"231 -116 OFFCURVE",
+"231 -125 CURVE SMOOTH",
+"231 -135 OFFCURVE",
+"237 -142 OFFCURVE",
+"237 -153 CURVE SMOOTH",
+"237 -211 OFFCURVE",
+"196 -256 OFFCURVE",
+"196 -263 CURVE",
+"209 -263 LINE SMOOTH",
+"222 -263 OFFCURVE",
+"246 -216 OFFCURVE",
+"268 -167 CURVE SMOOTH",
+"273 -154 OFFCURVE",
+"277 -141 OFFCURVE",
+"277 -128 CURVE SMOOTH",
+"277 -110 OFFCURVE",
+"264 -99 OFFCURVE",
+"251 -99 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"234 -100 OFFCURVE",
+"230 -115 OFFCURVE",
+"230 -124 CURVE SMOOTH",
+"230 -137 OFFCURVE",
+"235 -139 OFFCURVE",
+"232 -159 CURVE SMOOTH",
+"227 -202 OFFCURVE",
+"189 -243 OFFCURVE",
+"188 -249 CURVE",
+"199 -249 LINE SMOOTH",
+"212 -249 OFFCURVE",
+"240 -209 OFFCURVE",
+"261 -165 CURVE SMOOTH",
+"267 -153 OFFCURVE",
+"271 -138 OFFCURVE",
+"272 -126 CURVE SMOOTH",
+"274 -110 OFFCURVE",
+"264 -100 OFFCURVE",
+"251 -100 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0326;
+},
+{
+color = 3;
+glyphname = cedillacomb;
+lastChange = "2022-03-01 11:00:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _cedilla;
+position = "{250, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = _cedilla;
+position = "{250, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"190 -195 OFFCURVE",
+"272 -175 OFFCURVE",
+"272 -125 CURVE SMOOTH",
+"272 -87 OFFCURVE",
+"223 -64 OFFCURVE",
+"223 -39 CURVE SMOOTH",
+"223 -33 OFFCURVE",
+"226 -28 OFFCURVE",
+"230 -22 CURVE",
+"240 -13 OFFCURVE",
+"252 -5 OFFCURVE",
+"262 0 CURVE",
+"261 3 OFFCURVE",
+"251 5 OFFCURVE",
+"245 5 CURVE SMOOTH",
+"242 5 LINE",
+"227 0 OFFCURVE",
+"213 -8 OFFCURVE",
+"203 -19 CURVE SMOOTH",
+"192 -31 OFFCURVE",
+"188 -42 OFFCURVE",
+"188 -51 CURVE SMOOTH",
+"188 -81 OFFCURVE",
+"234 -96 OFFCURVE",
+"234 -128 CURVE SMOOTH",
+"234 -171 OFFCURVE",
+"188 -174 OFFCURVE",
+"160 -178 CURVE SMOOTH",
+"141 -181 OFFCURVE",
+"130 -183 OFFCURVE",
+"130 -187 CURVE SMOOTH",
+"130 -191 OFFCURVE",
+"134 -195 OFFCURVE",
+"155 -195 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"190 -195 OFFCURVE",
+"272 -175 OFFCURVE",
+"272 -125 CURVE SMOOTH",
+"272 -87 OFFCURVE",
+"223 -64 OFFCURVE",
+"223 -39 CURVE SMOOTH",
+"223 -33 OFFCURVE",
+"226 -28 OFFCURVE",
+"230 -22 CURVE",
+"240 -13 OFFCURVE",
+"252 -5 OFFCURVE",
+"262 0 CURVE",
+"261 3 OFFCURVE",
+"251 5 OFFCURVE",
+"245 5 CURVE SMOOTH",
+"242 5 LINE",
+"227 0 OFFCURVE",
+"213 -8 OFFCURVE",
+"203 -19 CURVE SMOOTH",
+"192 -31 OFFCURVE",
+"188 -42 OFFCURVE",
+"188 -51 CURVE SMOOTH",
+"188 -81 OFFCURVE",
+"234 -96 OFFCURVE",
+"234 -128 CURVE SMOOTH",
+"234 -171 OFFCURVE",
+"188 -174 OFFCURVE",
+"160 -178 CURVE SMOOTH",
+"141 -181 OFFCURVE",
+"130 -183 OFFCURVE",
+"130 -187 CURVE SMOOTH",
+"130 -191 OFFCURVE",
+"134 -195 OFFCURVE",
+"155 -195 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0327;
+},
+{
+color = 3;
+glyphname = ogonekcomb;
+lastChange = "2022-03-01 11:00:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = _ogonek;
+position = "{250, 0}";
+}
+);
+background = {
+anchors = (
+{
+name = _ogonek;
+position = "{250, 0}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"228 -157 OFFCURVE",
+"275 -142 OFFCURVE",
+"275 -126 CURVE SMOOTH",
+"275 -123 OFFCURVE",
+"273 -123 OFFCURVE",
+"271 -123 CURVE SMOOTH",
+"263 -123 OFFCURVE",
+"237 -134 OFFCURVE",
+"213 -134 CURVE SMOOTH",
+"197 -134 OFFCURVE",
+"185 -125 OFFCURVE",
+"186 -112 CURVE",
+"185 -97 OFFCURVE",
+"199 -77 OFFCURVE",
+"215 -59 CURVE SMOOTH",
+"232 -43 OFFCURVE",
+"251 -26 OFFCURVE",
+"265 3 CURVE",
+"264 4 OFFCURVE",
+"258 5 OFFCURVE",
+"253 5 CURVE SMOOTH",
+"244 5 OFFCURVE",
+"245 0 OFFCURVE",
+"193 -45 CURVE SMOOTH",
+"170 -64 OFFCURVE",
+"144 -86 OFFCURVE",
+"144 -114 CURVE SMOOTH",
+"146 -147 OFFCURVE",
+"175 -157 OFFCURVE",
+"204 -157 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"228 -157 OFFCURVE",
+"275 -142 OFFCURVE",
+"275 -126 CURVE SMOOTH",
+"275 -123 OFFCURVE",
+"273 -123 OFFCURVE",
+"271 -123 CURVE SMOOTH",
+"263 -123 OFFCURVE",
+"237 -134 OFFCURVE",
+"213 -134 CURVE SMOOTH",
+"197 -134 OFFCURVE",
+"185 -125 OFFCURVE",
+"186 -112 CURVE",
+"185 -97 OFFCURVE",
+"199 -77 OFFCURVE",
+"215 -59 CURVE SMOOTH",
+"232 -43 OFFCURVE",
+"251 -26 OFFCURVE",
+"265 3 CURVE",
+"264 4 OFFCURVE",
+"258 5 OFFCURVE",
+"253 5 CURVE SMOOTH",
+"244 5 OFFCURVE",
+"245 0 OFFCURVE",
+"193 -45 CURVE SMOOTH",
+"170 -64 OFFCURVE",
+"144 -86 OFFCURVE",
+"144 -114 CURVE SMOOTH",
+"146 -147 OFFCURVE",
+"175 -157 OFFCURVE",
+"204 -157 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0328;
+},
+{
+color = 3;
+glyphname = brevebelowcomb;
+lastChange = "2022-03-01 13:06:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"281 -203 OFFCURVE",
+"358 -183 OFFCURVE",
+"392 -119 CURVE SMOOTH",
+"394 -116 OFFCURVE",
+"395 -112 OFFCURVE",
+"395 -109 CURVE SMOOTH",
+"395 -104 OFFCURVE",
+"392 -101 OFFCURVE",
+"388 -101 CURVE SMOOTH",
+"385 -101 OFFCURVE",
+"382 -103 OFFCURVE",
+"378 -106 CURVE",
+"353 -135 OFFCURVE",
+"303 -169 OFFCURVE",
+"251 -169 CURVE SMOOTH",
+"221 -169 OFFCURVE",
+"196 -153 OFFCURVE",
+"198 -109 CURVE SMOOTH",
+"198 -103 OFFCURVE",
+"194 -100 OFFCURVE",
+"191 -100 CURVE SMOOTH",
+"186 -100 OFFCURVE",
+"179 -105 OFFCURVE",
+"176 -113 CURVE SMOOTH",
+"174 -122 OFFCURVE",
+"174 -132 OFFCURVE",
+"174 -140 CURVE SMOOTH",
+"174 -184 OFFCURVE",
+"198 -203 OFFCURVE",
+"250 -203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 -194 OFFCURVE",
+"305 -176 OFFCURVE",
+"333 -118 CURVE SMOOTH",
+"335 -115 OFFCURVE",
+"336 -111 OFFCURVE",
+"336 -109 CURVE SMOOTH",
+"336 -104 OFFCURVE",
+"333 -101 OFFCURVE",
+"330 -101 CURVE SMOOTH",
+"327 -101 OFFCURVE",
+"324 -103 OFFCURVE",
+"321 -106 CURVE",
+"301 -132 OFFCURVE",
+"261 -161 OFFCURVE",
+"216 -161 CURVE SMOOTH",
+"191 -161 OFFCURVE",
+"170 -149 OFFCURVE",
+"171 -109 CURVE SMOOTH",
+"171 -103 OFFCURVE",
+"168 -100 OFFCURVE",
+"164 -100 CURVE SMOOTH",
+"159 -100 OFFCURVE",
+"156 -103 OFFCURVE",
+"153 -111 CURVE SMOOTH",
+"150 -120 OFFCURVE",
+"149 -129 OFFCURVE",
+"149 -138 CURVE SMOOTH",
+"149 -171 OFFCURVE",
+"169 -194 OFFCURVE",
+"211 -194 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 032E;
+},
+{
+color = 3;
+glyphname = macronbelowcomb;
+lastChange = "2022-03-01 13:07:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+components = (
+{
+name = macroncomb;
+transform = "{1, 0, 0, 1, 0, -1005}";
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 -154 OFFCURVE",
+"226 -152 OFFCURVE",
+"248 -150 CURVE SMOOTH",
+"274 -148 OFFCURVE",
+"300 -146 OFFCURVE",
+"328 -146 CURVE SMOOTH",
+"334 -146 OFFCURVE",
+"336 -137 OFFCURVE",
+"336 -134 CURVE SMOOTH",
+"336 -127 OFFCURVE",
+"294 -120 OFFCURVE",
+"245 -120 CURVE SMOOTH",
+"186 -120 OFFCURVE",
+"164 -120 OFFCURVE",
+"164 -129 CURVE SMOOTH",
+"164 -137 OFFCURVE",
+"171 -154 OFFCURVE",
+"180 -154 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0331;
+},
+{
+color = 3;
+glyphname = strokeshortcomb;
+lastChange = "2022-03-01 13:09:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{250, 175}";
+}
+);
+background = {
+anchors = (
+{
+name = _center;
+position = "{250, -125}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 -143 OFFCURVE",
+"220 -140 OFFCURVE",
+"247 -138 CURVE SMOOTH",
+"280 -136 OFFCURVE",
+"313 -134 OFFCURVE",
+"347 -134 CURVE SMOOTH",
+"355 -134 OFFCURVE",
+"358 -125 OFFCURVE",
+"358 -122 CURVE SMOOTH",
+"358 -111 OFFCURVE",
+"272 -107 OFFCURVE",
+"244 -107 CURVE SMOOTH",
+"223 -107 OFFCURVE",
+"161 -106 OFFCURVE",
+"144 -115 CURVE SMOOTH",
+"142 -116 LINE",
+"143 -124 OFFCURVE",
+"157 -143 OFFCURVE",
+"163 -143 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 157 OFFCURVE",
+"220 160 OFFCURVE",
+"247 162 CURVE SMOOTH",
+"280 164 OFFCURVE",
+"313 166 OFFCURVE",
+"347 166 CURVE SMOOTH",
+"355 166 OFFCURVE",
+"358 175 OFFCURVE",
+"358 178 CURVE SMOOTH",
+"358 189 OFFCURVE",
+"272 193 OFFCURVE",
+"244 193 CURVE SMOOTH",
+"223 193 OFFCURVE",
+"161 194 OFFCURVE",
+"144 185 CURVE SMOOTH",
+"142 184 LINE",
+"143 176 OFFCURVE",
+"157 157 OFFCURVE",
+"163 157 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+unicode = 0335;
+},
+{
+color = 3;
+glyphname = dieresis;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = dieresiscomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 00A8;
+},
+{
+color = 3;
+glyphname = dotaccent;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = dotaccentcomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02D9;
+},
+{
+color = 3;
+glyphname = grave;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = gravecomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 0060;
+},
+{
+color = 3;
+glyphname = acute;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = acutecomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 00B4;
+},
+{
+color = 3;
+glyphname = hungarumlaut;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = hungarumlautcomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02DD;
+},
+{
+color = 3;
+glyphname = circumflex;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = circumflexcomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02C6;
+},
+{
+color = 3;
+glyphname = caron;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = caroncomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02C7;
+},
+{
+color = 3;
+glyphname = breve;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = brevecomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02D8;
+},
+{
+color = 3;
+glyphname = ring;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = ringcomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02DA;
+},
+{
+color = 3;
+glyphname = tilde;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = tildecomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02DC;
+},
+{
+color = 3;
+glyphname = macron;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = macroncomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 00AF;
+},
+{
+color = 3;
+glyphname = cedilla;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = cedillacomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 00B8;
+},
+{
+color = 3;
+glyphname = ogonek;
+lastChange = "2022-03-01 13:26:22 +0000";
+layers = (
+{
+components = (
+{
+name = ogonekcomb;
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+unicode = 02DB;
+},
+{
+color = 3;
+glyphname = dieresiscomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"315 344 OFFCURVE",
+"325 364 OFFCURVE",
+"329 376 CURVE",
+"331 388 OFFCURVE",
+"341 397 OFFCURVE",
+"352 413 CURVE",
+"352 417 LINE",
+"351 420 OFFCURVE",
+"348 420 OFFCURVE",
+"347 420 CURVE SMOOTH",
+"332 420 OFFCURVE",
+"279 395 OFFCURVE",
+"279 374 CURVE SMOOTH",
+"279 365 OFFCURVE",
+"289 344 OFFCURVE",
+"299 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 344 OFFCURVE",
+"194 364 OFFCURVE",
+"198 376 CURVE SMOOTH",
+"201 388 OFFCURVE",
+"210 397 OFFCURVE",
+"221 413 CURVE",
+"221 417 LINE",
+"220 420 OFFCURVE",
+"217 420 OFFCURVE",
+"216 420 CURVE SMOOTH",
+"202 420 OFFCURVE",
+"148 395 OFFCURVE",
+"148 374 CURVE SMOOTH",
+"148 365 OFFCURVE",
+"158 344 OFFCURVE",
+"168 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 344 OFFCURVE",
+"325 364 OFFCURVE",
+"329 376 CURVE",
+"331 388 OFFCURVE",
+"341 397 OFFCURVE",
+"352 413 CURVE",
+"352 417 LINE",
+"351 420 OFFCURVE",
+"348 420 OFFCURVE",
+"347 420 CURVE SMOOTH",
+"332 420 OFFCURVE",
+"279 395 OFFCURVE",
+"279 374 CURVE SMOOTH",
+"279 365 OFFCURVE",
+"289 344 OFFCURVE",
+"299 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 344 OFFCURVE",
+"194 364 OFFCURVE",
+"198 376 CURVE SMOOTH",
+"201 388 OFFCURVE",
+"210 397 OFFCURVE",
+"221 413 CURVE",
+"221 417 LINE",
+"220 420 OFFCURVE",
+"217 420 OFFCURVE",
+"216 420 CURVE SMOOTH",
+"202 420 OFFCURVE",
+"148 395 OFFCURVE",
+"148 374 CURVE SMOOTH",
+"148 365 OFFCURVE",
+"158 344 OFFCURVE",
+"168 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = dotaccentcomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"250 343 OFFCURVE",
+"265 348 OFFCURVE",
+"272 360 CURVE SMOOTH",
+"278 371 OFFCURVE",
+"282 382 OFFCURVE",
+"282 388 CURVE SMOOTH",
+"282 400 OFFCURVE",
+"275 407 OFFCURVE",
+"257 407 CURVE SMOOTH",
+"238 407 OFFCURVE",
+"218 386 OFFCURVE",
+"218 361 CURVE SMOOTH",
+"218 358 OFFCURVE",
+"218 355 OFFCURVE",
+"219 352 CURVE SMOOTH",
+"220 346 OFFCURVE",
+"229 343 OFFCURVE",
+"238 343 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 343 OFFCURVE",
+"265 348 OFFCURVE",
+"272 360 CURVE SMOOTH",
+"278 371 OFFCURVE",
+"282 382 OFFCURVE",
+"282 388 CURVE SMOOTH",
+"282 400 OFFCURVE",
+"275 407 OFFCURVE",
+"257 407 CURVE SMOOTH",
+"238 407 OFFCURVE",
+"218 386 OFFCURVE",
+"218 361 CURVE SMOOTH",
+"218 358 OFFCURVE",
+"218 355 OFFCURVE",
+"219 352 CURVE SMOOTH",
+"220 346 OFFCURVE",
+"229 343 OFFCURVE",
+"238 343 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = gravecomb.case;
+lastChange = "2022-03-01 11:21:35 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"270 342 OFFCURVE",
+"280 345 OFFCURVE",
+"280 349 CURVE SMOOTH",
+"280 350 OFFCURVE",
+"279 351 OFFCURVE",
+"276 352 CURVE SMOOTH",
+"240 367 OFFCURVE",
+"173 436 OFFCURVE",
+"158 446 CURVE SMOOTH",
+"153 450 OFFCURVE",
+"139 452 OFFCURVE",
+"128 452 CURVE SMOOTH",
+"118 452 OFFCURVE",
+"110 451 OFFCURVE",
+"110 446 CURVE SMOOTH",
+"111 439 OFFCURVE",
+"113 429 OFFCURVE",
+"144 409 CURVE SMOOTH",
+"149 406 OFFCURVE",
+"254 346 OFFCURVE",
+"263 345 CURVE"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"270 342 OFFCURVE",
+"280 345 OFFCURVE",
+"281 349 CURVE SMOOTH",
+"281 350 OFFCURVE",
+"280 351 OFFCURVE",
+"277 352 CURVE SMOOTH",
+"243 367 OFFCURVE",
+"184 436 OFFCURVE",
+"171 446 CURVE SMOOTH",
+"166 450 OFFCURVE",
+"152 452 OFFCURVE",
+"141 452 CURVE SMOOTH",
+"131 452 OFFCURVE",
+"123 451 OFFCURVE",
+"123 446 CURVE SMOOTH",
+"123 439 OFFCURVE",
+"123 429 OFFCURVE",
+"152 409 CURVE SMOOTH",
+"157 406 OFFCURVE",
+"254 346 OFFCURVE",
+"263 345 CURVE"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = acutecomb.case;
+lastChange = "2022-03-01 11:21:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"233 344 OFFCURVE",
+"235 344 OFFCURVE",
+"237 345 CURVE",
+"245 346 OFFCURVE",
+"351 406 OFFCURVE",
+"356 409 CURVE SMOOTH",
+"387 429 OFFCURVE",
+"389 439 OFFCURVE",
+"390 446 CURVE SMOOTH",
+"390 451 OFFCURVE",
+"382 452 OFFCURVE",
+"372 452 CURVE SMOOTH",
+"361 452 OFFCURVE",
+"347 450 OFFCURVE",
+"342 446 CURVE SMOOTH",
+"326 436 OFFCURVE",
+"260 367 OFFCURVE",
+"224 352 CURVE SMOOTH",
+"215 348 OFFCURVE",
+"223 344 OFFCURVE",
+"230 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"233 344 OFFCURVE",
+"235 344 OFFCURVE",
+"237 345 CURVE",
+"245 346 OFFCURVE",
+"359 406 OFFCURVE",
+"364 409 CURVE SMOOTH",
+"397 429 OFFCURVE",
+"401 439 OFFCURVE",
+"403 446 CURVE SMOOTH",
+"403 451 OFFCURVE",
+"395 452 OFFCURVE",
+"385 452 CURVE SMOOTH",
+"374 452 OFFCURVE",
+"360 450 OFFCURVE",
+"355 446 CURVE SMOOTH",
+"337 436 OFFCURVE",
+"263 367 OFFCURVE",
+"225 352 CURVE SMOOTH",
+"215 348 OFFCURVE",
+"223 344 OFFCURVE",
+"230 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = hungarumlautcomb.case;
+lastChange = "2022-03-01 11:21:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"202 344 OFFCURVE",
+"207 346 OFFCURVE",
+"209 351 CURVE SMOOTH",
+"213 360 OFFCURVE",
+"251 454 OFFCURVE",
+"254 463 CURVE SMOOTH",
+"256 470 OFFCURVE",
+"245 473 OFFCURVE",
+"233 473 CURVE SMOOTH",
+"220 473 OFFCURVE",
+"208 470 OFFCURVE",
+"208 462 CURVE SMOOTH",
+"208 433 OFFCURVE",
+"202 394 OFFCURVE",
+"192 361 CURVE SMOOTH",
+"191 359 OFFCURVE",
+"191 356 OFFCURVE",
+"191 354 CURVE SMOOTH",
+"191 347 OFFCURVE",
+"194 344 OFFCURVE",
+"198 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 344 OFFCURVE",
+"310 346 OFFCURVE",
+"312 351 CURVE SMOOTH",
+"317 360 OFFCURVE",
+"355 454 OFFCURVE",
+"358 463 CURVE SMOOTH",
+"360 470 OFFCURVE",
+"348 473 OFFCURVE",
+"336 473 CURVE SMOOTH",
+"324 473 OFFCURVE",
+"311 470 OFFCURVE",
+"311 462 CURVE SMOOTH",
+"311 433 OFFCURVE",
+"305 394 OFFCURVE",
+"295 361 CURVE SMOOTH",
+"294 359 OFFCURVE",
+"294 356 OFFCURVE",
+"294 354 CURVE SMOOTH",
+"294 347 OFFCURVE",
+"297 344 OFFCURVE",
+"301 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"202 344 OFFCURVE",
+"207 346 OFFCURVE",
+"210 351 CURVE SMOOTH",
+"215 360 OFFCURVE",
+"265 454 OFFCURVE",
+"269 463 CURVE SMOOTH",
+"271 470 OFFCURVE",
+"261 473 OFFCURVE",
+"249 473 CURVE SMOOTH",
+"236 473 OFFCURVE",
+"223 470 OFFCURVE",
+"222 462 CURVE SMOOTH",
+"219 433 OFFCURVE",
+"208 394 OFFCURVE",
+"194 361 CURVE SMOOTH",
+"193 359 OFFCURVE",
+"192 356 OFFCURVE",
+"192 354 CURVE SMOOTH",
+"191 347 OFFCURVE",
+"194 344 OFFCURVE",
+"198 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 344 OFFCURVE",
+"310 346 OFFCURVE",
+"313 351 CURVE SMOOTH",
+"319 360 OFFCURVE",
+"369 454 OFFCURVE",
+"373 463 CURVE SMOOTH",
+"375 470 OFFCURVE",
+"364 473 OFFCURVE",
+"352 473 CURVE SMOOTH",
+"340 473 OFFCURVE",
+"326 470 OFFCURVE",
+"325 462 CURVE SMOOTH",
+"322 433 OFFCURVE",
+"311 394 OFFCURVE",
+"297 361 CURVE SMOOTH",
+"296 359 OFFCURVE",
+"295 356 OFFCURVE",
+"295 354 CURVE SMOOTH",
+"294 347 OFFCURVE",
+"297 344 OFFCURVE",
+"301 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = caroncomb.alt.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _topright;
+position = "{250, 585}";
+}
+);
+background = {
+anchors = (
+{
+name = _topright;
+position = "{250, 585}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"256 434 OFFCURVE",
+"266 445 OFFCURVE",
+"272 459 CURVE SMOOTH",
+"288 490 OFFCURVE",
+"315 568 OFFCURVE",
+"318 577 CURVE SMOOTH",
+"320 584 OFFCURVE",
+"309 587 OFFCURVE",
+"297 587 CURVE SMOOTH",
+"284 587 OFFCURVE",
+"271 584 OFFCURVE",
+"271 576 CURVE SMOOTH",
+"271 547 OFFCURVE",
+"264 486 OFFCURVE",
+"251 444 CURVE SMOOTH",
+"249 437 OFFCURVE",
+"250 434 OFFCURVE",
+"252 434 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 434 OFFCURVE",
+"266 445 OFFCURVE",
+"272 459 CURVE SMOOTH",
+"288 490 OFFCURVE",
+"315 568 OFFCURVE",
+"318 577 CURVE SMOOTH",
+"320 584 OFFCURVE",
+"309 587 OFFCURVE",
+"297 587 CURVE SMOOTH",
+"284 587 OFFCURVE",
+"271 584 OFFCURVE",
+"271 576 CURVE SMOOTH",
+"271 547 OFFCURVE",
+"264 486 OFFCURVE",
+"251 444 CURVE SMOOTH",
+"249 437 OFFCURVE",
+"250 434 OFFCURVE",
+"252 434 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb.case;
+lastChange = "2022-03-01 11:21:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"148 344 OFFCURVE",
+"150 345 OFFCURVE",
+"152 346 CURVE",
+"158 347 OFFCURVE",
+"253 414 OFFCURVE",
+"264 424 CURVE",
+"269 416 OFFCURVE",
+"350 347 OFFCURVE",
+"354 346 CURVE",
+"359 342 OFFCURVE",
+"367 345 OFFCURVE",
+"367 350 CURVE SMOOTH",
+"367 351 OFFCURVE",
+"366 353 OFFCURVE",
+"364 354 CURVE SMOOTH",
+"357 359 OFFCURVE",
+"287 457 OFFCURVE",
+"283 459 CURVE",
+"281 461 OFFCURVE",
+"276 462 OFFCURVE",
+"271 462 CURVE SMOOTH",
+"264 462 OFFCURVE",
+"257 461 OFFCURVE",
+"254 459 CURVE SMOOTH",
+"247 455 OFFCURVE",
+"160 363 OFFCURVE",
+"143 354 CURVE",
+"136 349 OFFCURVE",
+"141 344 OFFCURVE",
+"147 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"148 344 OFFCURVE",
+"150 345 OFFCURVE",
+"152 346 CURVE",
+"158 347 OFFCURVE",
+"262 414 OFFCURVE",
+"274 424 CURVE",
+"278 416 OFFCURVE",
+"350 347 OFFCURVE",
+"354 346 CURVE",
+"359 342 OFFCURVE",
+"367 345 OFFCURVE",
+"368 350 CURVE SMOOTH",
+"368 351 OFFCURVE",
+"367 353 OFFCURVE",
+"365 354 CURVE SMOOTH",
+"359 359 OFFCURVE",
+"301 457 OFFCURVE",
+"297 459 CURVE",
+"295 461 OFFCURVE",
+"290 462 OFFCURVE",
+"285 462 CURVE SMOOTH",
+"278 462 OFFCURVE",
+"271 461 OFFCURVE",
+"268 459 CURVE SMOOTH",
+"261 455 OFFCURVE",
+"162 363 OFFCURVE",
+"144 354 CURVE",
+"137 349 OFFCURVE",
+"141 344 OFFCURVE",
+"147 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = caroncomb.case;
+lastChange = "2022-03-01 11:22:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"256 344 OFFCURVE",
+"263 345 OFFCURVE",
+"266 347 CURVE",
+"274 350 OFFCURVE",
+"360 442 OFFCURVE",
+"377 452 CURVE SMOOTH",
+"384 457 OFFCURVE",
+"380 462 OFFCURVE",
+"375 462 CURVE SMOOTH",
+"374 462 OFFCURVE",
+"372 461 OFFCURVE",
+"370 460 CURVE",
+"363 459 OFFCURVE",
+"268 392 OFFCURVE",
+"256 382 CURVE",
+"252 390 OFFCURVE",
+"172 459 OFFCURVE",
+"167 460 CURVE",
+"162 464 OFFCURVE",
+"153 461 OFFCURVE",
+"153 456 CURVE SMOOTH",
+"153 455 OFFCURVE",
+"154 453 OFFCURVE",
+"156 452 CURVE SMOOTH",
+"164 447 OFFCURVE",
+"233 349 OFFCURVE",
+"237 347 CURVE",
+"239 345 OFFCURVE",
+"245 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 344 OFFCURVE",
+"263 345 OFFCURVE",
+"266 347 CURVE",
+"275 350 OFFCURVE",
+"372 442 OFFCURVE",
+"390 452 CURVE SMOOTH",
+"398 457 OFFCURVE",
+"394 462 OFFCURVE",
+"389 462 CURVE SMOOTH",
+"388 462 OFFCURVE",
+"386 461 OFFCURVE",
+"384 460 CURVE",
+"377 459 OFFCURVE",
+"274 392 OFFCURVE",
+"261 382 CURVE",
+"258 390 OFFCURVE",
+"186 459 OFFCURVE",
+"181 460 CURVE",
+"177 464 OFFCURVE",
+"167 461 OFFCURVE",
+"167 456 CURVE SMOOTH",
+"167 455 OFFCURVE",
+"167 453 OFFCURVE",
+"169 452 CURVE SMOOTH",
+"177 447 OFFCURVE",
+"234 349 OFFCURVE",
+"237 347 CURVE",
+"239 345 OFFCURVE",
+"245 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"281 344 OFFCURVE",
+"358 364 OFFCURVE",
+"392 428 CURVE SMOOTH",
+"394 431 OFFCURVE",
+"395 435 OFFCURVE",
+"395 438 CURVE SMOOTH",
+"395 443 OFFCURVE",
+"392 446 OFFCURVE",
+"388 446 CURVE SMOOTH",
+"385 446 OFFCURVE",
+"382 444 OFFCURVE",
+"378 441 CURVE",
+"353 412 OFFCURVE",
+"303 378 OFFCURVE",
+"251 378 CURVE SMOOTH",
+"221 378 OFFCURVE",
+"196 394 OFFCURVE",
+"198 438 CURVE SMOOTH",
+"198 444 OFFCURVE",
+"194 447 OFFCURVE",
+"191 447 CURVE SMOOTH",
+"186 447 OFFCURVE",
+"179 442 OFFCURVE",
+"176 434 CURVE SMOOTH",
+"174 425 OFFCURVE",
+"174 415 OFFCURVE",
+"174 407 CURVE SMOOTH",
+"174 363 OFFCURVE",
+"198 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"281 344 OFFCURVE",
+"358 364 OFFCURVE",
+"392 428 CURVE SMOOTH",
+"394 431 OFFCURVE",
+"395 435 OFFCURVE",
+"395 438 CURVE SMOOTH",
+"395 443 OFFCURVE",
+"392 446 OFFCURVE",
+"388 446 CURVE SMOOTH",
+"385 446 OFFCURVE",
+"382 444 OFFCURVE",
+"378 441 CURVE",
+"353 412 OFFCURVE",
+"303 378 OFFCURVE",
+"251 378 CURVE SMOOTH",
+"221 378 OFFCURVE",
+"196 394 OFFCURVE",
+"198 438 CURVE SMOOTH",
+"198 444 OFFCURVE",
+"194 447 OFFCURVE",
+"191 447 CURVE SMOOTH",
+"186 447 OFFCURVE",
+"179 442 OFFCURVE",
+"176 434 CURVE SMOOTH",
+"174 425 OFFCURVE",
+"174 415 OFFCURVE",
+"174 407 CURVE SMOOTH",
+"174 363 OFFCURVE",
+"198 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = ringcomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"300 344 OFFCURVE",
+"348 390 OFFCURVE",
+"350 436 CURVE SMOOTH",
+"350 460 OFFCURVE",
+"334 486 OFFCURVE",
+"307 486 CURVE SMOOTH",
+"284 486 OFFCURVE",
+"262 473 OFFCURVE",
+"247 455 CURVE",
+"230 455 OFFCURVE",
+"209 401 OFFCURVE",
+"209 379 CURVE SMOOTH",
+"209 357 OFFCURVE",
+"227 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 362 OFFCURVE",
+"247 372 OFFCURVE",
+"247 382 CURVE SMOOTH",
+"248 415 OFFCURVE",
+"264 434 OFFCURVE",
+"274 445 CURVE SMOOTH",
+"277 448 OFFCURVE",
+"278 451 OFFCURVE",
+"278 452 CURVE SMOOTH",
+"278 456 OFFCURVE",
+"272 455 OFFCURVE",
+"271 456 CURVE",
+"281 462 OFFCURVE",
+"291 469 OFFCURVE",
+"303 469 CURVE SMOOTH",
+"321 469 OFFCURVE",
+"324 447 OFFCURVE",
+"324 434 CURVE SMOOTH",
+"323 404 OFFCURVE",
+"298 362 OFFCURVE",
+"263 362 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 344 OFFCURVE",
+"348 390 OFFCURVE",
+"350 436 CURVE SMOOTH",
+"350 460 OFFCURVE",
+"334 486 OFFCURVE",
+"307 486 CURVE SMOOTH",
+"284 486 OFFCURVE",
+"262 473 OFFCURVE",
+"247 455 CURVE",
+"230 455 OFFCURVE",
+"209 401 OFFCURVE",
+"209 379 CURVE SMOOTH",
+"209 357 OFFCURVE",
+"227 344 OFFCURVE",
+"250 344 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 362 OFFCURVE",
+"247 372 OFFCURVE",
+"247 382 CURVE SMOOTH",
+"248 415 OFFCURVE",
+"264 434 OFFCURVE",
+"274 445 CURVE SMOOTH",
+"277 448 OFFCURVE",
+"278 451 OFFCURVE",
+"278 452 CURVE SMOOTH",
+"278 456 OFFCURVE",
+"272 455 OFFCURVE",
+"271 456 CURVE",
+"281 462 OFFCURVE",
+"291 469 OFFCURVE",
+"303 469 CURVE SMOOTH",
+"321 469 OFFCURVE",
+"324 447 OFFCURVE",
+"324 434 CURVE SMOOTH",
+"323 404 OFFCURVE",
+"298 362 OFFCURVE",
+"263 362 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = ringcomb_acutecomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = ringcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 110, 90}";
+}
+);
+};
+components = (
+{
+name = ringcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 110, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = tildecomb.case;
+lastChange = "2022-03-01 11:22:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"323 344 OFFCURVE",
+"349 366 OFFCURVE",
+"357 399 CURVE",
+"357 403 OFFCURVE",
+"356 403 OFFCURVE",
+"348 403 CURVE",
+"345 392 OFFCURVE",
+"325 376 OFFCURVE",
+"302 376 CURVE SMOOTH",
+"276 376 OFFCURVE",
+"238 404 OFFCURVE",
+"207 404 CURVE SMOOTH",
+"177 404 OFFCURVE",
+"151 382 OFFCURVE",
+"144 350 CURVE SMOOTH",
+"143 345 OFFCURVE",
+"146 345 OFFCURVE",
+"151 345 CURVE",
+"155 357 OFFCURVE",
+"174 372 OFFCURVE",
+"198 372 CURVE SMOOTH",
+"224 372 OFFCURVE",
+"262 344 OFFCURVE",
+"292 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"319 344 OFFCURVE",
+"348 366 OFFCURVE",
+"360 399 CURVE",
+"360 403 OFFCURVE",
+"359 403 OFFCURVE",
+"351 403 CURVE",
+"347 392 OFFCURVE",
+"325 376 OFFCURVE",
+"302 376 CURVE SMOOTH",
+"276 376 OFFCURVE",
+"241 404 OFFCURVE",
+"210 404 CURVE SMOOTH",
+"180 404 OFFCURVE",
+"152 382 OFFCURVE",
+"141 350 CURVE SMOOTH",
+"139 345 OFFCURVE",
+"142 345 OFFCURVE",
+"147 345 CURVE",
+"153 357 OFFCURVE",
+"173 372 OFFCURVE",
+"197 372 CURVE SMOOTH",
+"223 372 OFFCURVE",
+"258 344 OFFCURVE",
+"288 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = tildecomb_dotaccentcomb.case;
+lastChange = "2022-03-01 13:15:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = dotaccentcomb;
+transform = "{1, 0, 0, 1, 0, 90}";
+}
+);
+};
+components = (
+{
+name = tildecomb.case;
+},
+{
+alignment = -1;
+name = dotaccentcomb.case;
+transform = "{1, 0, 0, 1, 20, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = tildecomb_macroncomb.case;
+lastChange = "2022-03-01 13:15:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = tildecomb;
+},
+{
+alignment = -1;
+name = macroncomb;
+transform = "{1, 0, 0, 1, 0, 80}";
+}
+);
+};
+components = (
+{
+name = tildecomb.case;
+},
+{
+alignment = -1;
+name = macroncomb.case;
+transform = "{1, 0, 0, 1, 10, 80}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = macroncomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 359 OFFCURVE",
+"220 362 OFFCURVE",
+"247 364 CURVE SMOOTH",
+"280 366 OFFCURVE",
+"313 368 OFFCURVE",
+"347 368 CURVE SMOOTH",
+"355 368 OFFCURVE",
+"358 377 OFFCURVE",
+"358 380 CURVE SMOOTH",
+"358 391 OFFCURVE",
+"272 395 OFFCURVE",
+"244 395 CURVE SMOOTH",
+"223 395 OFFCURVE",
+"161 396 OFFCURVE",
+"144 387 CURVE SMOOTH",
+"142 386 LINE",
+"143 378 OFFCURVE",
+"157 359 OFFCURVE",
+"163 359 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 359 OFFCURVE",
+"220 362 OFFCURVE",
+"247 364 CURVE SMOOTH",
+"280 366 OFFCURVE",
+"313 368 OFFCURVE",
+"347 368 CURVE SMOOTH",
+"355 368 OFFCURVE",
+"358 377 OFFCURVE",
+"358 380 CURVE SMOOTH",
+"358 391 OFFCURVE",
+"272 395 OFFCURVE",
+"244 395 CURVE SMOOTH",
+"223 395 OFFCURVE",
+"161 396 OFFCURVE",
+"144 387 CURVE SMOOTH",
+"142 386 LINE",
+"143 378 OFFCURVE",
+"157 359 OFFCURVE",
+"163 359 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = hookabovecomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"248 343 OFFCURVE",
+"261 345 OFFCURVE",
+"261 349 CURVE",
+"265 361 OFFCURVE",
+"280 377 OFFCURVE",
+"301 393 CURVE SMOOTH",
+"327 411 OFFCURVE",
+"357 432 OFFCURVE",
+"357 459 CURVE SMOOTH",
+"357 488 OFFCURVE",
+"329 496 OFFCURVE",
+"302 496 CURVE SMOOTH",
+"278 496 OFFCURVE",
+"229 482 OFFCURVE",
+"228 467 CURVE",
+"227 463 OFFCURVE",
+"229 460 OFFCURVE",
+"235 460 CURVE SMOOTH",
+"243 460 OFFCURVE",
+"266 474 OFFCURVE",
+"290 474 CURVE SMOOTH",
+"305 474 OFFCURVE",
+"315 467 OFFCURVE",
+"315 457 CURVE SMOOTH",
+"315 443 OFFCURVE",
+"299 423 OFFCURVE",
+"280 406 CURVE SMOOTH",
+"262 391 OFFCURVE",
+"241 375 OFFCURVE",
+"238 349 CURVE SMOOTH",
+"238 345 OFFCURVE",
+"240 343 OFFCURVE",
+"245 343 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"248 343 OFFCURVE",
+"261 345 OFFCURVE",
+"261 349 CURVE",
+"265 361 OFFCURVE",
+"280 377 OFFCURVE",
+"301 393 CURVE SMOOTH",
+"327 411 OFFCURVE",
+"357 432 OFFCURVE",
+"357 459 CURVE SMOOTH",
+"357 488 OFFCURVE",
+"329 496 OFFCURVE",
+"302 496 CURVE SMOOTH",
+"278 496 OFFCURVE",
+"229 482 OFFCURVE",
+"228 467 CURVE",
+"227 463 OFFCURVE",
+"229 460 OFFCURVE",
+"235 460 CURVE SMOOTH",
+"243 460 OFFCURVE",
+"266 474 OFFCURVE",
+"290 474 CURVE SMOOTH",
+"305 474 OFFCURVE",
+"315 467 OFFCURVE",
+"315 457 CURVE SMOOTH",
+"315 443 OFFCURVE",
+"299 423 OFFCURVE",
+"280 406 CURVE SMOOTH",
+"262 391 OFFCURVE",
+"241 375 OFFCURVE",
+"238 349 CURVE SMOOTH",
+"238 345 OFFCURVE",
+"240 343 OFFCURVE",
+"245 343 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = dblgravecomb.case;
+lastChange = "2022-03-01 11:22:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 344 OFFCURVE",
+"195 344 OFFCURVE",
+"197 344 CURVE SMOOTH",
+"203 344 OFFCURVE",
+"208 346 OFFCURVE",
+"208 349 CURVE SMOOTH",
+"208 350 OFFCURVE",
+"207 351 OFFCURVE",
+"204 352 CURVE SMOOTH",
+"168 367 OFFCURVE",
+"101 436 OFFCURVE",
+"86 446 CURVE SMOOTH",
+"81 450 OFFCURVE",
+"67 452 OFFCURVE",
+"56 452 CURVE SMOOTH",
+"46 452 OFFCURVE",
+"38 451 OFFCURVE",
+"38 446 CURVE SMOOTH",
+"39 439 OFFCURVE",
+"41 429 OFFCURVE",
+"72 409 CURVE SMOOTH",
+"77 406 OFFCURVE",
+"182 346 OFFCURVE",
+"191 345 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 334 OFFCURVE",
+"311 336 OFFCURVE",
+"311 339 CURVE SMOOTH",
+"311 340 OFFCURVE",
+"310 341 OFFCURVE",
+"308 343 CURVE",
+"276 361 OFFCURVE",
+"224 435 OFFCURVE",
+"210 445 CURVE",
+"205 450 OFFCURVE",
+"187 455 OFFCURVE",
+"176 455 CURVE SMOOTH",
+"170 455 OFFCURVE",
+"166 454 OFFCURVE",
+"165 451 CURVE",
+"165 444 OFFCURVE",
+"165 434 OFFCURVE",
+"191 412 CURVE",
+"196 409 OFFCURVE",
+"287 339 OFFCURVE",
+"296 337 CURVE",
+"298 335 OFFCURVE",
+"300 334 OFFCURVE",
+"303 334 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"194 344 OFFCURVE",
+"196 344 OFFCURVE",
+"198 344 CURVE SMOOTH",
+"204 344 OFFCURVE",
+"209 346 OFFCURVE",
+"210 349 CURVE SMOOTH",
+"210 350 OFFCURVE",
+"209 351 OFFCURVE",
+"206 352 CURVE SMOOTH",
+"172 367 OFFCURVE",
+"114 436 OFFCURVE",
+"100 446 CURVE SMOOTH",
+"95 450 OFFCURVE",
+"81 452 OFFCURVE",
+"70 452 CURVE SMOOTH",
+"60 452 OFFCURVE",
+"52 451 OFFCURVE",
+"52 446 CURVE SMOOTH",
+"52 439 OFFCURVE",
+"53 429 OFFCURVE",
+"81 409 CURVE SMOOTH",
+"86 406 OFFCURVE",
+"183 346 OFFCURVE",
+"192 345 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 334 OFFCURVE",
+"311 336 OFFCURVE",
+"312 339 CURVE SMOOTH",
+"312 340 OFFCURVE",
+"311 341 OFFCURVE",
+"309 343 CURVE",
+"279 361 OFFCURVE",
+"236 435 OFFCURVE",
+"224 445 CURVE",
+"219 450 OFFCURVE",
+"202 455 OFFCURVE",
+"191 455 CURVE SMOOTH",
+"185 455 OFFCURVE",
+"181 454 OFFCURVE",
+"179 451 CURVE",
+"179 444 OFFCURVE",
+"177 434 OFFCURVE",
+"201 412 CURVE",
+"205 409 OFFCURVE",
+"288 339 OFFCURVE",
+"296 337 CURVE",
+"298 335 OFFCURVE",
+"300 334 OFFCURVE",
+"303 334 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = breveinvertedcomb.case;
+lastChange = "2022-03-01 11:01:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"356 344 OFFCURVE",
+"363 349 OFFCURVE",
+"366 356 CURVE",
+"368 366 OFFCURVE",
+"368 376 OFFCURVE",
+"368 384 CURVE SMOOTH",
+"368 428 OFFCURVE",
+"321 447 OFFCURVE",
+"291 447 CURVE SMOOTH",
+"260 447 OFFCURVE",
+"183 427 OFFCURVE",
+"150 363 CURVE SMOOTH",
+"148 359 OFFCURVE",
+"147 355 OFFCURVE",
+"147 352 CURVE SMOOTH",
+"147 348 OFFCURVE",
+"150 345 OFFCURVE",
+"154 345 CURVE SMOOTH",
+"157 345 OFFCURVE",
+"160 347 OFFCURVE",
+"164 350 CURVE",
+"189 379 OFFCURVE",
+"239 413 OFFCURVE",
+"290 413 CURVE SMOOTH",
+"321 413 OFFCURVE",
+"345 396 OFFCURVE",
+"343 352 CURVE SMOOTH",
+"343 347 OFFCURVE",
+"347 344 OFFCURVE",
+"351 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"356 344 OFFCURVE",
+"363 349 OFFCURVE",
+"366 356 CURVE",
+"368 366 OFFCURVE",
+"368 376 OFFCURVE",
+"368 384 CURVE SMOOTH",
+"368 428 OFFCURVE",
+"321 447 OFFCURVE",
+"291 447 CURVE SMOOTH",
+"260 447 OFFCURVE",
+"183 427 OFFCURVE",
+"150 363 CURVE SMOOTH",
+"148 359 OFFCURVE",
+"147 355 OFFCURVE",
+"147 352 CURVE SMOOTH",
+"147 348 OFFCURVE",
+"150 345 OFFCURVE",
+"154 345 CURVE SMOOTH",
+"157 345 OFFCURVE",
+"160 347 OFFCURVE",
+"164 350 CURVE",
+"189 379 OFFCURVE",
+"239 413 OFFCURVE",
+"290 413 CURVE SMOOTH",
+"321 413 OFFCURVE",
+"345 396 OFFCURVE",
+"343 352 CURVE SMOOTH",
+"343 347 OFFCURVE",
+"347 344 OFFCURVE",
+"351 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = commaturnedabovecomb.case;
+lastChange = "2022-03-01 11:23:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+},
+{
+name = top;
+position = "{250, 384}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"272 344 OFFCURVE",
+"272 361 OFFCURVE",
+"272 370 CURVE SMOOTH",
+"272 380 OFFCURVE",
+"266 387 OFFCURVE",
+"266 398 CURVE SMOOTH",
+"266 456 OFFCURVE",
+"307 501 OFFCURVE",
+"307 508 CURVE",
+"294 508 LINE SMOOTH",
+"281 508 OFFCURVE",
+"257 461 OFFCURVE",
+"235 412 CURVE SMOOTH",
+"230 399 OFFCURVE",
+"226 386 OFFCURVE",
+"226 373 CURVE SMOOTH",
+"226 355 OFFCURVE",
+"239 344 OFFCURVE",
+"252 344 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"272 344 OFFCURVE",
+"274 361 OFFCURVE",
+"275 370 CURVE SMOOTH",
+"276 380 OFFCURVE",
+"271 387 OFFCURVE",
+"273 398 CURVE SMOOTH",
+"280 456 OFFCURVE",
+"329 501 OFFCURVE",
+"330 508 CURVE",
+"314 508 LINE SMOOTH",
+"299 508 OFFCURVE",
+"271 461 OFFCURVE",
+"243 412 CURVE SMOOTH",
+"237 399 OFFCURVE",
+"231 386 OFFCURVE",
+"230 373 CURVE SMOOTH",
+"227 355 OFFCURVE",
+"239 344 OFFCURVE",
+"252 344 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = dotbelowcomb.case;
+lastChange = "2022-03-01 13:01:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -164 OFFCURVE",
+"265 -159 OFFCURVE",
+"272 -147 CURVE SMOOTH",
+"278 -136 OFFCURVE",
+"282 -125 OFFCURVE",
+"282 -119 CURVE SMOOTH",
+"282 -107 OFFCURVE",
+"275 -100 OFFCURVE",
+"257 -100 CURVE SMOOTH",
+"238 -100 OFFCURVE",
+"218 -121 OFFCURVE",
+"218 -146 CURVE SMOOTH",
+"218 -149 OFFCURVE",
+"218 -152 OFFCURVE",
+"219 -155 CURVE SMOOTH",
+"220 -161 OFFCURVE",
+"229 -164 OFFCURVE",
+"238 -164 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -164 OFFCURVE",
+"265 -159 OFFCURVE",
+"272 -147 CURVE SMOOTH",
+"278 -136 OFFCURVE",
+"282 -125 OFFCURVE",
+"282 -119 CURVE SMOOTH",
+"282 -107 OFFCURVE",
+"275 -100 OFFCURVE",
+"257 -100 CURVE SMOOTH",
+"238 -100 OFFCURVE",
+"218 -121 OFFCURVE",
+"218 -146 CURVE SMOOTH",
+"218 -149 OFFCURVE",
+"218 -152 OFFCURVE",
+"219 -155 CURVE SMOOTH",
+"220 -161 OFFCURVE",
+"229 -164 OFFCURVE",
+"238 -164 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = dieresisbelowcomb.case;
+lastChange = "2022-03-01 13:01:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"315 -176 OFFCURVE",
+"325 -156 OFFCURVE",
+"329 -144 CURVE",
+"331 -132 OFFCURVE",
+"341 -123 OFFCURVE",
+"352 -107 CURVE",
+"352 -103 LINE",
+"351 -100 OFFCURVE",
+"348 -100 OFFCURVE",
+"347 -100 CURVE SMOOTH",
+"332 -100 OFFCURVE",
+"279 -125 OFFCURVE",
+"279 -146 CURVE SMOOTH",
+"279 -155 OFFCURVE",
+"289 -176 OFFCURVE",
+"299 -176 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 -176 OFFCURVE",
+"194 -156 OFFCURVE",
+"198 -144 CURVE SMOOTH",
+"201 -132 OFFCURVE",
+"210 -123 OFFCURVE",
+"221 -107 CURVE",
+"221 -103 LINE",
+"220 -100 OFFCURVE",
+"217 -100 OFFCURVE",
+"216 -100 CURVE SMOOTH",
+"202 -100 OFFCURVE",
+"148 -125 OFFCURVE",
+"148 -146 CURVE SMOOTH",
+"148 -155 OFFCURVE",
+"158 -176 OFFCURVE",
+"168 -176 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 -176 OFFCURVE",
+"325 -156 OFFCURVE",
+"329 -144 CURVE",
+"331 -132 OFFCURVE",
+"341 -123 OFFCURVE",
+"352 -107 CURVE",
+"352 -103 LINE",
+"351 -100 OFFCURVE",
+"348 -100 OFFCURVE",
+"347 -100 CURVE SMOOTH",
+"332 -100 OFFCURVE",
+"279 -125 OFFCURVE",
+"279 -146 CURVE SMOOTH",
+"279 -155 OFFCURVE",
+"289 -176 OFFCURVE",
+"299 -176 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 -176 OFFCURVE",
+"194 -156 OFFCURVE",
+"198 -144 CURVE SMOOTH",
+"201 -132 OFFCURVE",
+"210 -123 OFFCURVE",
+"221 -107 CURVE",
+"221 -103 LINE",
+"220 -100 OFFCURVE",
+"217 -100 OFFCURVE",
+"216 -100 CURVE SMOOTH",
+"202 -100 OFFCURVE",
+"148 -125 OFFCURVE",
+"148 -146 CURVE SMOOTH",
+"148 -155 OFFCURVE",
+"158 -176 OFFCURVE",
+"168 -176 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = commaaccentcomb.case;
+lastChange = "2022-03-01 13:15:48 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"231 -99 OFFCURVE",
+"231 -116 OFFCURVE",
+"231 -125 CURVE SMOOTH",
+"231 -135 OFFCURVE",
+"237 -142 OFFCURVE",
+"237 -153 CURVE SMOOTH",
+"237 -211 OFFCURVE",
+"196 -256 OFFCURVE",
+"196 -263 CURVE",
+"209 -263 LINE SMOOTH",
+"222 -263 OFFCURVE",
+"246 -216 OFFCURVE",
+"268 -167 CURVE SMOOTH",
+"273 -154 OFFCURVE",
+"277 -141 OFFCURVE",
+"277 -128 CURVE SMOOTH",
+"277 -110 OFFCURVE",
+"264 -99 OFFCURVE",
+"251 -99 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"231 -99 OFFCURVE",
+"229 -116 OFFCURVE",
+"228 -125 CURVE SMOOTH",
+"227 -135 OFFCURVE",
+"232 -142 OFFCURVE",
+"230 -153 CURVE SMOOTH",
+"223 -211 OFFCURVE",
+"177 -256 OFFCURVE",
+"176 -263 CURVE",
+"189 -263 LINE SMOOTH",
+"204 -263 OFFCURVE",
+"236 -216 OFFCURVE",
+"262 -167 CURVE SMOOTH",
+"269 -154 OFFCURVE",
+"272 -141 OFFCURVE",
+"274 -128 CURVE SMOOTH",
+"276 -110 OFFCURVE",
+"264 -99 OFFCURVE",
+"251 -99 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = macronbelowcomb.case;
+lastChange = "2022-03-01 13:10:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{250, 0}";
+},
+{
+name = bottom;
+position = "{250, -140}";
+}
+);
+background = {
+components = (
+{
+name = macroncomb;
+transform = "{1, 0, 0, 1, 0, -1005}";
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"197 -154 OFFCURVE",
+"222 -152 OFFCURVE",
+"248 -150 CURVE SMOOTH",
+"278 -148 OFFCURVE",
+"308 -146 OFFCURVE",
+"341 -146 CURVE SMOOTH",
+"348 -146 OFFCURVE",
+"350 -137 OFFCURVE",
+"350 -134 CURVE SMOOTH",
+"350 -127 OFFCURVE",
+"301 -120 OFFCURVE",
+"244 -120 CURVE SMOOTH",
+"176 -120 OFFCURVE",
+"150 -120 OFFCURVE",
+"150 -129 CURVE SMOOTH",
+"150 -137 OFFCURVE",
+"158 -154 OFFCURVE",
+"169 -154 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = strokeshortcomb.case;
+lastChange = "2022-03-01 13:10:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{250, 175}";
+}
+);
+background = {
+anchors = (
+{
+name = _center;
+position = "{250, -125}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"193 -143 OFFCURVE",
+"220 -140 OFFCURVE",
+"247 -138 CURVE SMOOTH",
+"280 -136 OFFCURVE",
+"313 -134 OFFCURVE",
+"347 -134 CURVE SMOOTH",
+"355 -134 OFFCURVE",
+"358 -125 OFFCURVE",
+"358 -122 CURVE SMOOTH",
+"358 -111 OFFCURVE",
+"272 -107 OFFCURVE",
+"244 -107 CURVE SMOOTH",
+"223 -107 OFFCURVE",
+"161 -106 OFFCURVE",
+"144 -115 CURVE SMOOTH",
+"142 -116 LINE",
+"143 -124 OFFCURVE",
+"157 -143 OFFCURVE",
+"163 -143 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 157 OFFCURVE",
+"220 160 OFFCURVE",
+"247 162 CURVE SMOOTH",
+"280 164 OFFCURVE",
+"313 166 OFFCURVE",
+"347 166 CURVE SMOOTH",
+"355 166 OFFCURVE",
+"358 175 OFFCURVE",
+"358 178 CURVE SMOOTH",
+"358 189 OFFCURVE",
+"272 193 OFFCURVE",
+"244 193 CURVE SMOOTH",
+"223 193 OFFCURVE",
+"161 194 OFFCURVE",
+"144 185 CURVE SMOOTH",
+"142 184 LINE",
+"143 176 OFFCURVE",
+"157 157 OFFCURVE",
+"163 157 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_acutecomb;
+lastChange = "2022-03-01 13:17:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 50, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 54, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_gravecomb;
+lastChange = "2022-03-01 13:17:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 20, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 20, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_hookabovecomb;
+lastChange = "2022-03-01 13:17:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 40, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 38, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_tildecomb;
+lastChange = "2022-03-01 13:17:35 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 50, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 50, 120}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_acutecomb;
+lastChange = "2022-03-01 13:18:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 100, 90}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 93, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_gravecomb;
+lastChange = "2022-03-01 13:18:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 101, 100}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 101, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_hookabovecomb;
+lastChange = "2022-03-01 13:18:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 100, 80}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 78, 80}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_tildecomb;
+lastChange = "2022-03-01 13:22:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 0, 140}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 28, 130}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_acutecomb.case;
+lastChange = "2022-03-01 13:22:26 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 50, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb.case;
+},
+{
+alignment = -1;
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 54, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_gravecomb.case;
+lastChange = "2022-03-01 13:23:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 20, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb.case;
+},
+{
+alignment = -1;
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 10, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_hookabovecomb.case;
+lastChange = "2022-03-01 13:23:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 40, 100}";
+}
+);
+};
+components = (
+{
+name = brevecomb.case;
+},
+{
+alignment = -1;
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 30, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = brevecomb_tildecomb.case;
+lastChange = "2022-03-01 13:23:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = brevecomb;
+},
+{
+alignment = -1;
+name = tildecomb;
+transform = "{1, 0, 0, 1, 50, 120}";
+}
+);
+};
+components = (
+{
+name = brevecomb.case;
+},
+{
+alignment = -1;
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 60, 130}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_acutecomb.case;
+lastChange = "2022-03-01 13:23:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = acutecomb;
+transform = "{1, 0, 0, 1, 100, 90}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = acutecomb.case;
+transform = "{1, 0, 0, 1, 110, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_gravecomb.case;
+lastChange = "2022-03-01 13:24:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = gravecomb;
+transform = "{1, 0, 0, 1, 101, 100}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = gravecomb.case;
+transform = "{1, 0, 0, 1, 120, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_hookabovecomb.case;
+lastChange = "2022-03-01 13:25:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+alignment = -1;
+name = hookabovecomb;
+transform = "{1, 0, 0, 1, 100, 80}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = hookabovecomb.case;
+transform = "{1, 0, 0, 1, 100, 90}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
+},
+{
+color = 3;
+glyphname = circumflexcomb_tildecomb.case;
+lastChange = "2022-03-01 13:25:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+background = {
+anchors = (
+{
+name = _top;
+position = "{250, 244}";
+}
+);
+components = (
+{
+name = circumflexcomb;
+},
+{
+name = tildecomb;
+transform = "{1, 0, 0, 1, 0, 140}";
+}
+);
+};
+components = (
+{
+name = circumflexcomb.case;
+},
+{
+alignment = -1;
+name = tildecomb.case;
+transform = "{1, 0, 0, 1, 36, 140}";
+}
+);
+layerId = "64752FBD-EC7B-42BB-A7F3-340BB4BBD1AC";
+width = 500;
+}
+);
 }
 );
 instances = (


### PR DESCRIPTION
Original diacritics were too large for lowercase. They are now used as .case diacritics. Narrower and lower variants were made for the lowercase.

Anchors were repositioned to have them nearer to the base glyph. Uppercase and lowercase.